### PR TITLE
bugfix: loading a playlist starts playback on iOS

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -630,8 +630,6 @@ class TrackPlayerCore: NSObject {
       self.updatePlayerQueue(tracks: playlist.tracks)
       // Emit initial state (paused/stopped before play)
       self.emitStateChange()
-      // Automatically start playback after loading
-      self.play()
     } else {
       print("   ❌ Playlist NOT FOUND")
       print(String(repeating: "🎼", count: Constants.playlistSeparatorLength) + "\n")


### PR DESCRIPTION
### What

Prevents iOS from starting playback automatically when a playlist is loaded into the TrackPlayer

### Why

Consumers of this library may want to load a queue but defer playback until their users request playback to start