### PR TITLE
chore: add description in library `package.json`

### DIFF
--- a/react-native-nitro-player/package.json
+++ b/react-native-nitro-player/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-nitro-player",
   "version": "0.4.1-alpha.0",
-  "description": "react-native-nitro-player",
+  "description": "A powerful audio player library for React Native with playlist management, playback controls, and support for Android Auto and CarPlay",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
# Why

Spotted that description is the same as package name while browsing React Native Directory.

<img width="730" height="195" alt="Screenshot 2026-02-12 094440" src="https://github.com/user-attachments/assets/27f0f610-29bf-48f5-9036-ecc3b770254b" />

# How

Set description based on the first sentence from repository README. It should help with package discoverability in npm registry, and in the directory:
* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#description-1