### PR TITLE
fix: Resync currentindexes after a queue rebuild, Prevent Unnecessary Queue Rebuilds

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -45,10 +45,24 @@ internal fun TrackPlayerCore.rebuildQueueFromCurrentPosition() {
 
     // If current track was removed from the playlist, jump to best substitute
     val currentTrackId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
-    if (currentTrackId != null && currentTracks.none { it.id == currentTrackId }) {
+
+    if (
+        currentTrackId != null && 
+        currentTracks.none { it.id == currentTrackId } &&
+        currentTemporaryType == TrackPlayerCore.TemporaryType.NONE
+    ) {
         if (currentTracks.isEmpty()) return
         playFromIndexInternal(minOf(currentTrackIndex, currentTracks.size - 1))
         return
+    }
+
+    // Keep the logical playlist pointer in sync after playlist mutations.
+    // Without this, getActualQueue/getState can report a stale index until the next track transition.
+    if (currentTemporaryType == TrackPlayerCore.TemporaryType.NONE && currentTrackId != null) {
+        val resolvedIndex = currentTracks.indexOfFirst { it.id == currentTrackId }
+        if (resolvedIndex >= 0) {
+            currentTrackIndex = resolvedIndex
+        }
     }
 
     val newQueueTracks = ArrayList<TrackItem>(playNextStack.size + upNextQueue.size + currentTracks.size)

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -216,19 +216,33 @@ extension TrackPlayerCore {
     guard let player = self.player else { return }
 
     let currentItem = player.currentItem
+
+    guard let playingTrackId = currentItem?.trackId else {
+      NitroPlayerLogger.log("TrackPlayerCore", "❌ No current item or track ID found during queue rebuild")
+      return
+    }
+
     let playingItems = player.items()
 
     // If the currently playing AVPlayerItem is no longer in currentTracks,
     // delegate to rebuildQueueFromPlaylistIndex so the player immediately
     // starts what is now at currentTrackIndex in the updated list.
-    if let playingTrackId = currentItem?.trackId,
-      !currentTracks.contains(where: { $0.id == playingTrackId }) {
+    if !currentTracks.contains(where: { $0.id == playingTrackId }) &&
+      currentTemporaryType == .none {
       let targetIndex = currentTrackIndex < currentTracks.count
         ? currentTrackIndex : currentTracks.count - 1
       if targetIndex >= 0 {
         _ = rebuildQueueFromPlaylistIndex(index: targetIndex)
       }
       return
+    }
+
+    // Sync currentTrackIndex to the track's actual position after a playlist mutation
+    // (e.g. reorder). Without this, the remaining-tracks slice uses the stale index,
+    // causing wrong tracks to play after skip/next.
+    if currentTemporaryType == .none,
+      let newIndex = currentTracks.firstIndex(where: { $0.id == playingTrackId }) {
+      currentTrackIndex = newIndex
     }
 
     // Build the desired upcoming track list


### PR DESCRIPTION
I came across a few issues where the currentIndex reported by Nitro Player would get out of sync - normally when a `playNext` or `upNext` track is currently playing.

This PR introduces an additional update to the `currentTrackIndex` when rebuilding the AVQueue on iOS and the Queue on Android from the current track position.