### PR TITLE
fix: Additional URL Checks

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -120,6 +120,7 @@ class TrackPlayerCore private constructor(
             } else {
                 updatePlayerQueue(playlist.tracks)
             }
+            checkUpcomingTracksForUrls(lookaheadCount)
         }
 
     // ── Service binding ────────────────────────────────────────────────────

--- a/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
@@ -53,12 +53,14 @@ extension TrackPlayerCore {
       // If nothing is playing yet, do a full load
       guard self.player?.currentItem != nil else {
         self.updatePlayerQueue(tracks: playlist.tracks)
+        self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
         return
       }
 
       // Update tracks list without interrupting playback
       self.currentTracks = playlist.tracks
       self.rebuildAVQueueFromCurrentPosition()
+      self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
     }
 
     pendingPlaylistUpdateWorkItem = workItem

--- a/react-native-nitro-player/ios/playlist/PlaylistManager.swift
+++ b/react-native-nitro-player/ios/playlist/PlaylistManager.swift
@@ -172,6 +172,7 @@ class PlaylistManager {
     // Update TrackPlayerCore if this is the current playlist
     if currentPlaylistId == playlistId {
       TrackPlayerCore.shared.updatePlaylist(playlistId: playlistId)
+      TrackPlayerCore.shared.checkUpcomingTracksForUrls(lookahead: TrackPlayerCore.shared.lookaheadCount)
     }
 
     return true


### PR DESCRIPTION
Adds some additional checks for URLs when we are rebuilding the queue on iOS and Android

This handles the situation when the active playlist is being updated with tracks that don't have URLs