### PR TITLE
feat: support custom HTTP headers via extraPayload.headers

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -152,6 +152,25 @@ internal fun TrackPlayerCore.makeMediaItem(
 
     val effectiveUrl = downloadManager.getEffectiveUrl(track)
 
+    // Register headers from extraPayload if present
+    track.extraPayload?.let { payload ->
+        try {
+            if (payload.contains("headers") && payload.isObject("headers")) {
+                val map = payload.toHashMap()
+                val headersRaw = map["headers"]
+                if (headersRaw is Map<*, *>) {
+                    val headers = HashMap<String, String>()
+                    headersRaw.forEach { (k, v) ->
+                        if (k is String && v is String) headers[k] = v
+                    }
+                    if (headers.isNotEmpty()) {
+                        com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory.setHeadersForUrl(effectiveUrl, headers)
+                    }
+                }
+            }
+        } catch (_: Exception) {}
+    }
+
     return MediaItem
         .Builder()
         .setMediaId(customMediaId ?: track.id)

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
@@ -1,0 +1,56 @@
+package com.margelo.nitro.nitroplayer.media
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultHttpDataSource
+
+@UnstableApi
+class AuthAwareHttpDataSourceFactory : DataSource.Factory {
+    private val baseFactory = DefaultHttpDataSource.Factory()
+        .setAllowCrossProtocolRedirects(true)
+        .setConnectTimeoutMs(15_000)
+        .setReadTimeoutMs(15_000)
+
+    override fun createDataSource(): DataSource {
+        return AuthAwareHttpDataSource(baseFactory.createDataSource() as DefaultHttpDataSource)
+    }
+
+    companion object {
+        private val headersMap = HashMap<String, Map<String, String>>()
+
+        fun setHeadersForUrl(url: String, headers: Map<String, String>) {
+            headersMap[url] = headers
+        }
+
+        fun getHeadersForUrl(url: String): Map<String, String>? {
+            return headersMap[url]
+        }
+
+        fun clearHeaders() {
+            headersMap.clear()
+        }
+    }
+}
+
+@UnstableApi
+private class AuthAwareHttpDataSource(
+    private val delegate: DefaultHttpDataSource
+) : DataSource by delegate {
+
+    override fun open(dataSpec: DataSpec): Long {
+        val url = dataSpec.uri.toString()
+        val extraHeaders = AuthAwareHttpDataSourceFactory.getHeadersForUrl(url)
+
+        if (extraHeaders != null) {
+            val headers = HashMap(dataSpec.httpRequestHeaders)
+            headers.putAll(extraHeaders)
+            val newSpec = dataSpec.buildUpon()
+                .setHttpRequestHeaders(headers)
+                .build()
+            return delegate.open(newSpec)
+        }
+
+        return delegate.open(dataSpec)
+    }
+}

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
@@ -3,14 +3,17 @@ package com.margelo.nitro.nitroplayer.media
 import android.content.Context
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 
 /**
  * Builds an [ExoPlayer] with the standard NitroPlayer configuration.
  * The player uses the main application looper so that Media3's
  * [MediaSessionService] notification system works without thread conflicts.
  */
+@UnstableApi
 object ExoPlayerBuilder {
     fun build(context: Context): ExoPlayer {
         val loadControl =
@@ -37,10 +40,14 @@ object ExoPlayerBuilder {
                 .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build()
 
+        val mediaSourceFactory = DefaultMediaSourceFactory(context)
+            .setDataSourceFactory(AuthAwareHttpDataSourceFactory())
+
         return ExoPlayer
             .Builder(context)
             .setLoadControl(loadControl)
-            .setAudioAttributes(audioAttrs, /* handleAudioFocus */ true)
+            .setMediaSourceFactory(mediaSourceFactory)
+            .setAudioAttributes(audioAttrs, true)
             .setHandleAudioBecomingNoisy(true)
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .setPauseAtEndOfMediaItems(false)

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -40,8 +41,15 @@ object ExoPlayerBuilder {
                 .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build()
 
+        // DefaultDataSource wraps AuthAwareHttpDataSourceFactory for HTTP/HTTPS
+        // and handles file://, content://, asset:// natively
+        val dataSourceFactory = DefaultDataSource.Factory(
+            context,
+            AuthAwareHttpDataSourceFactory()
+        )
+
         val mediaSourceFactory = DefaultMediaSourceFactory(context)
-            .setDataSourceFactory(AuthAwareHttpDataSourceFactory())
+            .setDataSourceFactory(dataSourceFactory)
 
         return ExoPlayer
             .Builder(context)


### PR DESCRIPTION
**feat: Support custom HTTP headers for authenticated streaming**

Adds support for passing custom HTTP headers (e.g., Authorization) to ExoPlayer via extraPayload.headers on TrackItem. This enables streaming from services that require auth headers (Google Drive, Dropbox, etc.).

**Usage:**
```ts
const track: TrackItem = {
  id: '1',
  title: 'My Track',
  url: 'https://api.example.com/stream/123',
  extraPayload: {
    headers: { Authorization: 'Bearer token123' }
  }
};
```


**Implementation:**
- Custom AuthAwareHttpDataSourceFactory that injects per-URL headers into ExoPlayer's HTTP requests
- Headers are read from TrackItem.extraPayload.headers during MediaItem construction
- No changes to the public TypeScript API — uses existing extraPayload field