### PR TITLE
fix(android): Prevent Automatic Playback on Startup

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -32,7 +32,6 @@ internal fun TrackPlayerCore.rebuildQueueAndPlayFromIndex(index: Int) {
     exo.clearMediaItems()
     exo.setMediaItems(mediaItems)
     exo.seekToDefaultPosition(0)
-    exo.playWhenReady = true
     exo.prepare()
 }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the playback initialization logic in the `TrackPlayerCore.rebuildQueueAndPlayFromIndex` function. Specifically, it removes the line that sets `exo.playWhenReady = true`, so playback will no longer start automatically after rebuilding and preparing the queue.

We ran into an issue in Jellify - where when the queue was being restored on startup, playback would start up automatically.