### PR TITLE
fix: Prevent Duplicated Events on LoadPlaylist from Index

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -30,8 +30,7 @@ internal fun TrackPlayerCore.rebuildQueueAndPlayFromIndex(index: Int) {
 
     currentTrackIndex = index
     exo.clearMediaItems()
-    exo.setMediaItems(mediaItems)
-    exo.seekToDefaultPosition(0)
+    exo.setMediaItems(mediaItems, true)
     exo.prepare()
 }
 
@@ -123,7 +122,7 @@ internal fun TrackPlayerCore.updatePlayerQueue(tracks: List<TrackItem>) {
             val mediaId = if (playlistId.isNotEmpty()) "$playlistId:${track.id}" else track.id
             makeMediaItem(track, mediaId)
         }
-    exo.setMediaItems(mediaItems, false)
+    exo.setMediaItems(mediaItems, true)
     if (exo.playbackState == Player.STATE_IDLE && mediaItems.isNotEmpty()) {
         exo.prepare()
     }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerTempQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerTempQueue.kt
@@ -30,9 +30,13 @@ suspend fun TrackPlayerCore.loadPlaylist(
             }
 
         currentPlaylistId = playlistId
-        updatePlayerQueue(playlist.tracks)
-        if (targetIndex > 0) {
-            playFromIndexInternal(targetIndex)
+        if (targetIndex == 0) {
+            updatePlayerQueue(playlist.tracks)
+        } else {
+            // Bypass updatePlayerQueue to avoid emitting a spurious onTrackChange for index 0.
+            // Set currentTracks directly so rebuildQueueAndPlayFromIndex can use them.
+            currentTracks = playlist.tracks
+            rebuildQueueAndPlayFromIndex(targetIndex)
         }
         checkUpcomingTracksForUrls(lookaheadCount)
         notifyTemporaryQueueChange()

--- a/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
@@ -44,8 +44,13 @@ extension TrackPlayerCore {
       }
 
       self.currentPlaylistId = playlistId
-      self.updatePlayerQueue(tracks: playlist.tracks)
-      if targetIndex > 0 {
+      if targetIndex == 0 {
+        self.updatePlayerQueue(tracks: playlist.tracks)
+      } else {
+        // Bypass updatePlayerQueue to avoid emitting a spurious onTrackChange for index 0.
+        // Set currentTracks directly so rebuildQueueFromPlaylistIndex can use them.
+        self.currentTracks = playlist.tracks
+        self.preloadedAssets.removeAll()
         _ = self.rebuildQueueFromPlaylistIndex(index: targetIndex)
       }
       self.emitStateChange()


### PR DESCRIPTION
This pull request updates the logic for loading and updating playlists in both the Android and iOS implementations of the Nitro Player, focusing on more accurate queue handling and preventing unwanted track change events. The main improvements are to how queues are rebuilt and how media items are set, especially when starting playback from a non-zero index.

**Queue and playlist handling improvements:**

* In both Android (`TrackPlayerTempQueue.kt`) and iOS (`TrackPlayerTempQueue.swift`), the logic for loading a playlist now distinguishes between starting at index 0 and other indices. When starting from index 0, it uses the standard queue update method; for other indices, it sets the current tracks directly and rebuilds the queue from the target index, avoiding spurious `onTrackChange` events. [[1]](diffhunk://#diff-c6601b05e401e0a1235ffee1e30d876e15caaa9c94e9a10410f03b1402ba7c9eR33-R39) [[2]](diffhunk://#diff-a7a8ffce7074697871aa5f02a9a8d08ab7480b227a17984689a130da189079c8R47-R53)

* On Android, the `updatePlayerQueue` and `rebuildQueueAndPlayFromIndex` methods now call `exo.setMediaItems(mediaItems, true)` to ensure the player resets its position with the new media items, improving playback consistency. [[1]](diffhunk://#diff-6bd572f4ce17f4daa56e15127d05b06be1cfca6effc526ad15050a719d23ed13L33-R33) [[2]](diffhunk://#diff-6bd572f4ce17f4daa56e15127d05b06be1cfca6effc526ad15050a719d23ed13L126-R125)