### PR TITLE
fix: Previous Tracks Kept Playing when Lazy URLs were loaded

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -156,6 +156,12 @@ extension TrackPlayerCore {
       && !DownloadManagerCore.shared.isTrackDownloaded(trackId: targetTrack.id)
     if isLazyLoad {
       NitroPlayerLogger.log("TrackPlayerCore", "   ⏳ Lazy-load — deferring AVQueuePlayer setup; emitting track change for index \(index)")
+      // Clear old items immediately so the previous track stops while waiting for the URL to resolve
+      if let boundaryObserver = self.boundaryTimeObserver {
+        player?.removeTimeObserver(boundaryObserver)
+        self.boundaryTimeObserver = nil
+      }
+      player?.removeAllItems()
       self.currentTracks = fullPlaylist
       if let track = self.currentTracks[safe: index] {
         notifyTrackChange(track, .skip)


### PR DESCRIPTION
Previously, when I would feed in a playlist, then load up a new one, the previous track would continue playing when the incoming tracks had empty URLs and needed lazy loading.

This PR fixes this behavior, stopping the currently playing track when we are loading a new queue with lazily loaded URLs.