### PR TITLE
feat: support custom HTTP headers via extraPayload.headers (iOS + Android)

### DIFF
--- a/docs/content/docs/types/index.mdx
+++ b/docs/content/docs/types/index.mdx
@@ -30,6 +30,27 @@ interface TrackItem {
 }
 ```
 
+#### Custom HTTP headers
+
+Set `extraPayload.headers` to send custom request headers (e.g. `Authorization`)
+when streaming a remote `url`. This enables playback from authenticated endpoints
+(Google Drive, Dropbox, private APIs, etc.) on both iOS and Android. Headers are
+applied to remote streams only — downloaded/local files ignore them.
+
+```typescript
+const track: TrackItem = {
+  id: '1',
+  title: 'My Track',
+  artist: 'Artist',
+  album: 'Album',
+  duration: 0,
+  url: 'https://api.example.com/stream/123',
+  extraPayload: {
+    headers: { Authorization: 'Bearer token123' },
+  },
+};
+```
+
 ---
 
 ### Playlist

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -244,6 +244,7 @@ class TrackPlayerCore private constructor(
             }
         }
         scope.cancel()
+        com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory.clear()
         // Do NOT stop the service — it owns the player.
         // Unbind so Android can clean up if needed.
         if (serviceBound) {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -150,6 +150,23 @@ internal fun TrackPlayerCore.makeMediaItem(
 
     val effectiveUrl = downloadManager.getEffectiveUrl(track)
 
+    // Register custom HTTP headers (e.g. Authorization) from extraPayload.headers so they are
+    // injected into the request for this URL. Applies to remote streams only — see ExoPlayerBuilder.
+    track.extraPayload?.let { payload ->
+        try {
+            val headersRaw = payload.toHashMap()["headers"]
+            if (headersRaw is Map<*, *>) {
+                val headers = headersRaw
+                    .mapNotNull { (k, v) -> if (k is String && v is String) k to v else null }
+                    .toMap()
+                if (headers.isNotEmpty()) {
+                    com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory
+                        .setHeadersForUrl(effectiveUrl, headers)
+                }
+            }
+        } catch (_: Exception) {}
+    }
+
     return MediaItem
         .Builder()
         .setMediaId(customMediaId ?: track.id)

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
@@ -1,0 +1,48 @@
+package com.margelo.nitro.nitroplayer.media
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.ResolvingDataSource
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * HTTP [DataSource.Factory] that injects per-URL request headers (e.g. `Authorization`)
+ * into ExoPlayer's HTTP requests, enabling playback from authenticated endpoints.
+ *
+ * Headers are registered per effective URL via [setHeadersForUrl] during MediaItem
+ * construction and applied through a [ResolvingDataSource] just before each request opens.
+ *
+ * The registry is a [ConcurrentHashMap] because it is written on the player thread but
+ * read on ExoPlayer's loader threads.
+ */
+@UnstableApi
+class AuthAwareHttpDataSourceFactory : DataSource.Factory {
+    private val factory =
+        ResolvingDataSource.Factory(
+            DefaultHttpDataSource
+                .Factory()
+                .setAllowCrossProtocolRedirects(true)
+                .setConnectTimeoutMs(15_000)
+                .setReadTimeoutMs(15_000),
+            ResolvingDataSource.Resolver { dataSpec ->
+                val headers = headersMap[dataSpec.uri.toString()]
+                if (headers.isNullOrEmpty()) dataSpec else dataSpec.withAdditionalHeaders(headers)
+            },
+        )
+
+    override fun createDataSource(): DataSource = factory.createDataSource()
+
+    companion object {
+        private val headersMap = ConcurrentHashMap<String, Map<String, String>>()
+
+        fun setHeadersForUrl(url: String, headers: Map<String, String>) {
+            headersMap[url] = headers
+        }
+
+        /** Releases all registered headers. Call when the player is torn down. */
+        fun clear() {
+            headersMap.clear()
+        }
+    }
+}

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/ExoPlayerBuilder.kt
@@ -3,14 +3,18 @@ package com.margelo.nitro.nitroplayer.media
 import android.content.Context
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 
 /**
  * Builds an [ExoPlayer] with the standard NitroPlayer configuration.
  * The player uses the main application looper so that Media3's
  * [MediaSessionService] notification system works without thread conflicts.
  */
+@UnstableApi
 object ExoPlayerBuilder {
     fun build(context: Context): ExoPlayer {
         val loadControl =
@@ -37,9 +41,15 @@ object ExoPlayerBuilder {
                 .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build()
 
+        // DefaultDataSource routes http/https through AuthAwareHttpDataSourceFactory (so custom
+        // request headers can be injected) while handling file://, content:// and asset:// natively.
+        val dataSourceFactory = DefaultDataSource.Factory(context, AuthAwareHttpDataSourceFactory())
+        val mediaSourceFactory = DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory)
+
         return ExoPlayer
             .Builder(context)
             .setLoadControl(loadControl)
+            .setMediaSourceFactory(mediaSourceFactory)
             .setAudioAttributes(audioAttrs, /* handleAudioFocus */ true)
             .setHandleAudioBecomingNoisy(true)
             .setWakeMode(C.WAKE_MODE_NETWORK)

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -358,6 +358,37 @@ extension TrackPlayerCore {
     }
   }
 
+  /// Extracts custom HTTP headers (e.g. `Authorization`) from `extraPayload.headers`.
+  /// These are passed to AVURLAsset so authenticated remote streams can be played.
+  /// Returns nil when no string headers are present.
+  func httpHeaders(for track: TrackItem) -> [String: String]? {
+    // AnyMap.toDictionary() returns nested objects as [String: Any?] (optional values),
+    // so cast to that and unwrap each value rather than [String: Any].
+    guard let payload = track.extraPayload?.toDictionary(),
+      let headersValue = payload["headers"],
+      let raw = headersValue as? [String: Any?]
+    else { return nil }
+
+    var headers: [String: String] = [:]
+    for (key, value) in raw {
+      if let stringValue = value as? String {
+        headers[key] = stringValue
+      }
+    }
+    return headers.isEmpty ? nil : headers
+  }
+
+  /// Builds AVURLAsset options, attaching custom HTTP headers for remote (non-local) tracks.
+  private func assetOptions(for track: TrackItem, isLocal: Bool) -> [String: Any] {
+    var options: [String: Any] = [AVURLAssetPreferPreciseDurationAndTimingKey: true]
+    if !isLocal, let headers = httpHeaders(for: track) {
+      // AVURLAssetHTTPHeaderFieldsKey is the de-facto mechanism for per-asset request
+      // headers (also used by react-native-track-player). Applies to non-DRM HTTP(S).
+      options["AVURLAssetHTTPHeaderFieldsKey"] = headers
+    }
+    return options
+  }
+
   /// Creates a gapless-optimized AVPlayerItem with proper buffering configuration
   func createGaplessPlayerItem(for track: TrackItem, isPreload: Bool = false) -> AVPlayerItem? {
     let effectiveUrlString = DownloadManagerCore.shared.getEffectiveUrl(track: track)
@@ -396,9 +427,7 @@ extension TrackPlayerCore {
       asset = preloadedAsset
       NitroPlayerLogger.log("TrackPlayerCore", "🚀 Using preloaded asset for \(track.title)")
     } else {
-      asset = AVURLAsset(url: url, options: [
-        AVURLAssetPreferPreciseDurationAndTimingKey: true
-      ])
+      asset = AVURLAsset(url: url, options: assetOptions(for: track, isLocal: isLocal))
     }
 
     let item = AVPlayerItem(asset: asset)
@@ -463,9 +492,7 @@ extension TrackPlayerCore {
           url = remoteUrl
         }
 
-        let asset = AVURLAsset(url: url, options: [
-          AVURLAssetPreferPreciseDurationAndTimingKey: true
-        ])
+        let asset = AVURLAsset(url: url, options: self.assetOptions(for: track, isLocal: isLocal))
 
         asset.loadValuesAsynchronously(forKeys: Constants.preloadAssetKeys) { [weak self] in
           var allKeysLoaded = true


### PR DESCRIPTION
## feat: Support custom HTTP headers for authenticated streaming

Forwards custom HTTP headers (e.g. `Authorization`, `Referer`) from `TrackItem.extraPayload.headers` to the native players, enabling playback from services that require auth/hotlink headers (Google Drive, Dropbox, Bunny CDN, private APIs). No public TypeScript API change — uses the existing `extraPayload` field.

### Credit
Builds on @abdulaziz-git's Android implementation in #90. This PR mirrors that approach with hardening and adds the iOS side + docs.

### Changes vs #90
- **Android**: thread-safe header registry (`ConcurrentHashMap`), idiomatic `ResolvingDataSource` instead of a hand-rolled `DataSource` delegate, and cleanup on player teardown (no unbounded growth).
- **iOS** (new): headers applied via `AVURLAssetHTTPHeaderFieldsKey` at both asset-creation sites — playback and gapless preload (the preload path matters, or an unauthenticated asset gets cached and reused).
- **Docs**: custom-headers example added to the types reference.

### Notes
- Remote streams only; downloaded/local files ignore headers.
- iOS uses `AVURLAssetHTTPHeaderFieldsKey` (the de-facto mechanism, same as react-native-track-player) — not formally public API.

### Testing
Verified on both platforms against a hotlink-protected Bunny CDN: a disallowed `Referer` value is rejected (proving headers reach the server) while an allowed value plays.