### PR TITLE
feat: customizable Android notification small icon

### DIFF
--- a/docs/content/docs/api/track-player.mdx
+++ b/docs/content/docs/api/track-player.mdx
@@ -215,6 +215,7 @@ await TrackPlayer.configure({
   androidAutoEnabled: true,
   showInNotification: true,
   lookaheadCount: 10,
+  androidNotificationIcon: 'ic_notification', // Android-only custom notification icon
 });
 ```
 

--- a/docs/content/docs/types/index.mdx
+++ b/docs/content/docs/types/index.mdx
@@ -76,6 +76,7 @@ interface PlayerConfig {
   carPlayEnabled?: boolean;       // Default: false
   showInNotification?: boolean;   // Default: true
   lookaheadCount?: number;        // Default: 5 — tracks to preload URLs for
+  androidNotificationIcon?: string; // Android only — host-app drawable name for the notification small icon (white monochrome)
 }
 ```
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -15,6 +15,7 @@ void TrackPlayer.configure({
   carPlayEnabled: false,
   showInNotification: true,
   lookaheadCount: 3,
+  androidNotificationIcon: 'ic_notification', // Android Only
 });
 
 TrackPlayer.onTracksNeedUpdate(async (tracks, lookahead) => {

--- a/example/android/app/src/main/res/drawable/ic_notification.xml
+++ b/example/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,18 @@
+<!--
+  Notification small icon for the media notification.
+
+  Must be a white-on-transparent monochrome silhouette: Android tints the
+  alpha mask, so only the shape matters (a colored icon would render as a
+  solid white blob). Referenced from JS via:
+    TrackPlayer.configure({ androidNotificationIcon: 'ic_notification' })
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4L14,7h4L18,3h-6z" />
+</vector>

--- a/example/android/app/src/main/res/drawable/ic_notification_alt.xml
+++ b/example/android/app/src/main/res/drawable/ic_notification_alt.xml
@@ -1,0 +1,17 @@
+<!--
+  Alternate notification small icon (headphones) for testing live icon
+  switching via TrackPlayer.configure({ androidNotificationIcon: 'ic_notification_alt' }).
+
+  Like ic_notification.xml, this must be a white-on-transparent monochrome
+  silhouette — Android tints the alpha mask.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,1c-4.97,0 -9,4.03 -9,9v7c0,1.66 1.34,3 3,3h3v-8L5,12v-1c0,-3.87 3.13,-7 7,-7s7,3.13 7,7v1h-4v8h3c1.66,0 3,-1.34 3,-3v-7c0,-4.97 -4.03,-9 -9,-9z" />
+</vector>

--- a/example/src/screens/MoreScreen.tsx
+++ b/example/src/screens/MoreScreen.tsx
@@ -11,9 +11,15 @@ import {
 import { TrackPlayer, AudioDevices } from 'react-native-nitro-player';
 import { colors, commonStyles, spacing, borderRadius } from '../styles/theme';
 
+const NOTIFICATION_ICONS = [
+  { label: '🎵 Music Note', value: 'ic_notification' },
+  { label: '🎧 Headphones', value: 'ic_notification_alt' },
+];
+
 export default function MoreScreen() {
   const [volume, setVolume] = useState(50);
   const [audioDevices, setAudioDevices] = useState<any[]>([]);
+  const [notificationIcon, setNotificationIcon] = useState('ic_notification');
 
   useEffect(() => {
     if (Platform.OS === 'ios') {
@@ -31,6 +37,11 @@ export default function MoreScreen() {
   const handleVolumeChange = (newVolume: number) => {
     setVolume(newVolume);
     void TrackPlayer.setVolume(newVolume);
+  };
+
+  const handleNotificationIconChange = (icon: string) => {
+    setNotificationIcon(icon);
+    void TrackPlayer.configure({ androidNotificationIcon: icon });
   };
 
   return (
@@ -57,6 +68,37 @@ export default function MoreScreen() {
             </TouchableOpacity>
           </View>
         </View>
+
+        {/* Notification Icon (Android) */}
+        {Platform.OS === 'android' && (
+          <View style={commonStyles.section}>
+            <Text style={commonStyles.sectionTitle}>Notification Icon</Text>
+            <Text style={commonStyles.infoText}>
+              Switch the media notification small icon, then check the
+              notification shade / lock screen.
+            </Text>
+            <View style={styles.iconButtons}>
+              {NOTIFICATION_ICONS.map((icon) => {
+                const active = notificationIcon === icon.value;
+                return (
+                  <TouchableOpacity
+                    key={icon.value}
+                    style={[
+                      commonStyles.button,
+                      styles.iconButton,
+                      active && styles.iconButtonActive,
+                    ]}
+                    onPress={() => handleNotificationIconChange(icon.value)}>
+                    <Text style={commonStyles.buttonText}>
+                      {active ? '✓ ' : ''}
+                      {icon.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        )}
 
         {/* Audio Devices (iOS) */}
         {Platform.OS === 'ios' && (
@@ -95,6 +137,17 @@ const styles = StyleSheet.create({
   volumeControls: {
     flexDirection: 'row',
     gap: spacing.sm,
+  },
+  iconButtons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  iconButton: {
+    flex: 1,
+  },
+  iconButtonActive: {
+    backgroundColor: colors.success,
   },
   deviceCard: {
     backgroundColor: colors.cardBackground,

--- a/react-native-nitro-player/README.md
+++ b/react-native-nitro-player/README.md
@@ -129,8 +129,26 @@ await TrackPlayer.configure({
   androidAutoEnabled: true,
   carPlayEnabled: false,
   showInNotification: true,
+  // Android only: drawable resource name in your app for the notification small icon
+  androidNotificationIcon: 'ic_notification',
 })
 ```
+
+#### Customizing the Android notification icon
+
+`androidNotificationIcon` is the name of a drawable resource **in your app**
+(not this library) used as the small icon in the media notification and on the
+lock screen. To use it:
+
+1. Add a **white-on-transparent monochrome** drawable to your app, e.g.
+   `android/app/src/main/res/drawable/ic_notification.xml`. Android tints the
+   silhouette, so a full-color icon will render as a solid white blob.
+2. Pass its name (without extension or `R.drawable.` prefix) to `configure`:
+   `androidNotificationIcon: 'ic_notification'`.
+
+If the name can't be resolved, Media3's default small icon is used. Set it
+before playback starts so the first notification already has it (changes also
+apply live to a playing notification). This option is a no-op on iOS.
 
 ### 2. Create Playlists
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
@@ -8,6 +8,7 @@ import com.margelo.nitro.nitroplayer.Reason
 import com.margelo.nitro.nitroplayer.RepeatMode
 import com.margelo.nitro.nitroplayer.TrackPlayerState
 import com.margelo.nitro.nitroplayer.media.NitroPlayerMediaBrowserService
+import com.margelo.nitro.nitroplayer.media.NitroPlayerPlaybackService
 
 /**
  * Playback control — all public functions are suspend and execute on the player thread
@@ -95,6 +96,7 @@ suspend fun TrackPlayerCore.configure(config: PlayerConfig) =
     withPlayerContext {
         config.androidAutoEnabled?.let { NitroPlayerMediaBrowserService.isAndroidAutoEnabled = it }
         config.lookaheadCount?.let { lookaheadCount = it.toInt() }
+        config.androidNotificationIcon?.let { NitroPlayerPlaybackService.notificationSmallIconResName = it }
         mediaSessionManager?.configure(config.androidAutoEnabled, config.carPlayEnabled, config.showInNotification)
     }
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/PlaybackService.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/PlaybackService.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import android.os.Looper
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import com.margelo.nitro.nitroplayer.core.NitroPlayerLogger
@@ -29,11 +30,24 @@ class NitroPlayerPlaybackService : MediaSessionService() {
 
     companion object {
         const val ACTION_LOCAL_BIND = "com.margelo.nitro.nitroplayer.LOCAL_BIND"
+
+        @Volatile
+        var notificationSmallIconResName: String? = null
+            set(value) {
+                field = value
+                instance?.let { service ->
+                    service.mainHandler.post { service.applyNotificationSmallIcon() }
+                }
+            }
+
+        @Volatile
+        private var instance: NitroPlayerPlaybackService? = null
     }
 
     // ── Created in onCreate ────────────────────────────────────────────────
     private lateinit var player: ExoPlayer
     private var mediaSession: MediaSession? = null
+    private var notificationProvider: DefaultMediaNotificationProvider? = null
     private val mainHandler = Handler(Looper.getMainLooper())
 
     @Volatile
@@ -54,6 +68,7 @@ class NitroPlayerPlaybackService : MediaSessionService() {
     override fun onCreate() {
         super.onCreate()
         NitroPlayerLogger.log("PlaybackService") { "onCreate" }
+        instance = this
 
         // Build ExoPlayer on main looper (default)
         player = ExoPlayerBuilder.build(this)
@@ -65,12 +80,35 @@ class NitroPlayerPlaybackService : MediaSessionService() {
             .setCallback(MediaSessionCallbackFactory.create(this, playlistManager))
             .build()
 
-        // Explicitly register the session with the service so that
-        // MediaNotificationManager (created in super.onCreate()) can
-        // connect its internal MediaController and post notifications.
-        addSession(mediaSession!!)
+        val provider = DefaultMediaNotificationProvider.Builder(this).build()
+        notificationProvider = provider
+        applyNotificationSmallIcon()
+        setMediaNotificationProvider(provider)
 
-        // Media3 automatically handles the notification via DefaultMediaNotificationProvider.
+        addSession(mediaSession!!)
+    }
+
+    private fun applyNotificationSmallIcon() {
+        val name = notificationSmallIconResName ?: return
+        val provider = notificationProvider ?: return
+        val resId = resources.getIdentifier(name, "drawable", packageName)
+        if (resId == 0) {
+            NitroPlayerLogger.log("PlaybackService") {
+                "androidNotificationIcon '$name' not found in drawable resources — using default"
+            }
+            return
+        }
+        provider.setSmallIcon(resId)
+
+        // Live Refresh :)
+        val session = mediaSession
+        if (session != null && session.player.isPlaying) {
+            try {
+                onUpdateNotification(session, false)
+            } catch (e: Exception) {
+                NitroPlayerLogger.log("PlaybackService") { "notification refresh failed: ${e.message}" }
+            }
+        }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? =
@@ -93,6 +131,8 @@ class NitroPlayerPlaybackService : MediaSessionService() {
 
     override fun onDestroy() {
         NitroPlayerLogger.log("PlaybackService") { "onDestroy" }
+        if (instance === this) instance = null
+        notificationProvider = null
         mediaSession?.release()
         mediaSession = null
         player.release()

--- a/react-native-nitro-player/ios/HybridTrackPlayer.swift
+++ b/react-native-nitro-player/ios/HybridTrackPlayer.swift
@@ -113,7 +113,6 @@ final class HybridTrackPlayer: HybridTrackPlayerSpec {
   }
 
   // MARK: - Playback speed
-
   func setPlaybackSpeed(speed: Double) throws -> Promise<Void> {
     Promise.async { await self.core.setPlaybackSpeed(speed) }
   }

--- a/react-native-nitro-player/nitrogen/generated/android/c++/JPlayerConfig.hpp
+++ b/react-native-nitro-player/nitrogen/generated/android/c++/JPlayerConfig.hpp
@@ -11,6 +11,7 @@
 #include "PlayerConfig.hpp"
 
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::nitroplayer {
 
@@ -39,11 +40,14 @@ namespace margelo::nitro::nitroplayer {
       jni::local_ref<jni::JBoolean> showInNotification = this->getFieldValue(fieldShowInNotification);
       static const auto fieldLookaheadCount = clazz->getField<jni::JDouble>("lookaheadCount");
       jni::local_ref<jni::JDouble> lookaheadCount = this->getFieldValue(fieldLookaheadCount);
+      static const auto fieldAndroidNotificationIcon = clazz->getField<jni::JString>("androidNotificationIcon");
+      jni::local_ref<jni::JString> androidNotificationIcon = this->getFieldValue(fieldAndroidNotificationIcon);
       return PlayerConfig(
         androidAutoEnabled != nullptr ? std::make_optional(static_cast<bool>(androidAutoEnabled->value())) : std::nullopt,
         carPlayEnabled != nullptr ? std::make_optional(static_cast<bool>(carPlayEnabled->value())) : std::nullopt,
         showInNotification != nullptr ? std::make_optional(static_cast<bool>(showInNotification->value())) : std::nullopt,
-        lookaheadCount != nullptr ? std::make_optional(lookaheadCount->value()) : std::nullopt
+        lookaheadCount != nullptr ? std::make_optional(lookaheadCount->value()) : std::nullopt,
+        androidNotificationIcon != nullptr ? std::make_optional(androidNotificationIcon->toStdString()) : std::nullopt
       );
     }
 
@@ -53,7 +57,7 @@ namespace margelo::nitro::nitroplayer {
      */
     [[maybe_unused]]
     static jni::local_ref<JPlayerConfig::javaobject> fromCpp(const PlayerConfig& value) {
-      using JSignature = JPlayerConfig(jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JDouble>);
+      using JSignature = JPlayerConfig(jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JString>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -61,7 +65,8 @@ namespace margelo::nitro::nitroplayer {
         value.androidAutoEnabled.has_value() ? jni::JBoolean::valueOf(value.androidAutoEnabled.value()) : nullptr,
         value.carPlayEnabled.has_value() ? jni::JBoolean::valueOf(value.carPlayEnabled.value()) : nullptr,
         value.showInNotification.has_value() ? jni::JBoolean::valueOf(value.showInNotification.value()) : nullptr,
-        value.lookaheadCount.has_value() ? jni::JDouble::valueOf(value.lookaheadCount.value()) : nullptr
+        value.lookaheadCount.has_value() ? jni::JDouble::valueOf(value.lookaheadCount.value()) : nullptr,
+        value.androidNotificationIcon.has_value() ? jni::make_jstring(value.androidNotificationIcon.value()) : nullptr
       );
     }
   };

--- a/react-native-nitro-player/nitrogen/generated/android/kotlin/com/margelo/nitro/nitroplayer/PlayerConfig.kt
+++ b/react-native-nitro-player/nitrogen/generated/android/kotlin/com/margelo/nitro/nitroplayer/PlayerConfig.kt
@@ -28,7 +28,10 @@ data class PlayerConfig(
   val showInNotification: Boolean?,
   @DoNotStrip
   @Keep
-  val lookaheadCount: Double?
+  val lookaheadCount: Double?,
+  @DoNotStrip
+  @Keep
+  val androidNotificationIcon: String?
 ) {
   /* primary constructor */
 
@@ -40,8 +43,8 @@ data class PlayerConfig(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(androidAutoEnabled: Boolean?, carPlayEnabled: Boolean?, showInNotification: Boolean?, lookaheadCount: Double?): PlayerConfig {
-      return PlayerConfig(androidAutoEnabled, carPlayEnabled, showInNotification, lookaheadCount)
+    private fun fromCpp(androidAutoEnabled: Boolean?, carPlayEnabled: Boolean?, showInNotification: Boolean?, lookaheadCount: Double?, androidNotificationIcon: String?): PlayerConfig {
+      return PlayerConfig(androidAutoEnabled, carPlayEnabled, showInNotification, lookaheadCount, androidNotificationIcon)
     }
   }
 }

--- a/react-native-nitro-player/nitrogen/generated/ios/swift/PlayerConfig.swift
+++ b/react-native-nitro-player/nitrogen/generated/ios/swift/PlayerConfig.swift
@@ -18,7 +18,7 @@ public extension PlayerConfig {
   /**
    * Create a new instance of `PlayerConfig`.
    */
-  init(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Double?) {
+  init(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Double?, androidNotificationIcon: String?) {
     self.init({ () -> bridge.std__optional_bool_ in
       if let __unwrappedValue = androidAutoEnabled {
         return bridge.create_std__optional_bool_(__unwrappedValue)
@@ -40,6 +40,12 @@ public extension PlayerConfig {
     }(), { () -> bridge.std__optional_double_ in
       if let __unwrappedValue = lookaheadCount {
         return bridge.create_std__optional_double_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = androidNotificationIcon {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
         return .init()
       }
@@ -88,6 +94,18 @@ public extension PlayerConfig {
       if bridge.has_value_std__optional_double_(self.__lookaheadCount) {
         let __unwrapped = bridge.get_std__optional_double_(self.__lookaheadCount)
         return __unwrapped
+      } else {
+        return nil
+      }
+    }()
+  }
+  
+  @inline(__always)
+  var androidNotificationIcon: String? {
+    return { () -> String? in
+      if bridge.has_value_std__optional_std__string_(self.__androidNotificationIcon) {
+        let __unwrapped = bridge.get_std__optional_std__string_(self.__androidNotificationIcon)
+        return String(__unwrapped)
       } else {
         return nil
       }

--- a/react-native-nitro-player/nitrogen/generated/shared/c++/PlayerConfig.hpp
+++ b/react-native-nitro-player/nitrogen/generated/shared/c++/PlayerConfig.hpp
@@ -31,6 +31,7 @@
 
 
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::nitroplayer {
 
@@ -43,10 +44,11 @@ namespace margelo::nitro::nitroplayer {
     std::optional<bool> carPlayEnabled     SWIFT_PRIVATE;
     std::optional<bool> showInNotification     SWIFT_PRIVATE;
     std::optional<double> lookaheadCount     SWIFT_PRIVATE;
+    std::optional<std::string> androidNotificationIcon     SWIFT_PRIVATE;
 
   public:
     PlayerConfig() = default;
-    explicit PlayerConfig(std::optional<bool> androidAutoEnabled, std::optional<bool> carPlayEnabled, std::optional<bool> showInNotification, std::optional<double> lookaheadCount): androidAutoEnabled(androidAutoEnabled), carPlayEnabled(carPlayEnabled), showInNotification(showInNotification), lookaheadCount(lookaheadCount) {}
+    explicit PlayerConfig(std::optional<bool> androidAutoEnabled, std::optional<bool> carPlayEnabled, std::optional<bool> showInNotification, std::optional<double> lookaheadCount, std::optional<std::string> androidNotificationIcon): androidAutoEnabled(androidAutoEnabled), carPlayEnabled(carPlayEnabled), showInNotification(showInNotification), lookaheadCount(lookaheadCount), androidNotificationIcon(androidNotificationIcon) {}
 
   public:
     friend bool operator==(const PlayerConfig& lhs, const PlayerConfig& rhs) = default;
@@ -65,7 +67,8 @@ namespace margelo::nitro {
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "androidAutoEnabled"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "carPlayEnabled"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "showInNotification"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lookaheadCount")))
+        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lookaheadCount"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "androidNotificationIcon")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitroplayer::PlayerConfig& arg) {
@@ -74,6 +77,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "carPlayEnabled"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.carPlayEnabled));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "showInNotification"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.showInNotification));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "lookaheadCount"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.lookaheadCount));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "androidNotificationIcon"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.androidNotificationIcon));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -88,6 +92,7 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "carPlayEnabled")))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "showInNotification")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lookaheadCount")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "androidNotificationIcon")))) return false;
       return true;
     }
   };

--- a/react-native-nitro-player/src/types/PlayerQueue.ts
+++ b/react-native-nitro-player/src/types/PlayerQueue.ts
@@ -49,6 +49,6 @@ export interface PlayerConfig {
    * Higher values = more proactive loading, but more network requests
    */
   lookaheadCount?: number
-  
+
   androidNotificationIcon?: string
 }

--- a/react-native-nitro-player/src/types/PlayerQueue.ts
+++ b/react-native-nitro-player/src/types/PlayerQueue.ts
@@ -49,4 +49,6 @@ export interface PlayerConfig {
    * Higher values = more proactive loading, but more network requests
    */
   lookaheadCount?: number
+  
+  androidNotificationIcon?: string
 }


### PR DESCRIPTION
Add PlayerConfig.androidNotificationIcon so host apps can set the media notification small icon by drawable resource name. The playback service now owns a DefaultMediaNotificationProvider and resolves the icon from the app's resources at runtime, falling back to Media3's default when unset/unresolvable. Applies live to a playing notification. No-op on iOS.

Example: two sample drawables + a live icon switcher on the More screen.