### PR TITLE
fix(ios): follow http→https redirects on AVPlayer (#111)

### DIFF
--- a/docs/content/docs/types/index.mdx
+++ b/docs/content/docs/types/index.mdx
@@ -51,6 +51,23 @@ const track: TrackItem = {
 };
 ```
 
+#### HTTP (cleartext) URLs and redirects
+
+`http://` URLs that redirect to `https://` (e.g. a server-wide `308` upgrade) now play on
+both iOS and Android — the player follows the redirect to the final location. Two things are
+required for cleartext URLs to work at all, and **both are configured by the host app**, not
+by this library:
+
+- **iOS** — App Transport Security blocks cleartext by default. Add an `NSAppTransportSecurity`
+  exception for the domain (or `NSAllowsArbitraryLoads`) in your app's `Info.plist`, otherwise
+  the initial `http://` request never reaches the server and there is no redirect to follow.
+- **Android** — apps targeting API 28+ block cleartext by default. Set
+  `android:usesCleartextTraffic="true"` (or a network security config that allows the domain)
+  in your `AndroidManifest.xml`.
+
+Prefer passing `https://` URLs directly when you can: it skips the redirect round-trip and
+needs no cleartext exception.
+
 ---
 
 ### Playlist

--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -57,6 +57,10 @@ class TrackPlayerCore: NSObject {
   internal let preloadQueue = DispatchQueue(label: "com.nitroplayer.preload", qos: .utility)
   internal var didRequestUrlsForCurrentItem = false
 
+  // Follows http→https redirects that AVURLAsset otherwise silently drops (issue #111).
+  // Attached as the resource-loader delegate for cleartext-http assets only.
+  internal let redirectResolver = TrackPlayerRedirectResolver()
+
   // MARK: - Stall & network recovery
   // Whether the user/app wants playback ongoing (true after play(), false after pause()).
   internal var intendedToPlay = false
@@ -216,6 +220,7 @@ class TrackPlayerCore: NSObject {
       self.pathMonitor = nil
       self.preloadedAssets.removeAll()
       self.failedItemRetryCounts.removeAll()
+      self.redirectResolver.clear()
     }
   }
 

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -389,6 +389,20 @@ extension TrackPlayerCore {
     return options
   }
 
+  /// Builds the AVURLAsset for a track URL. Cleartext-`http` remote URLs are routed through
+  /// `redirectResolver` so AVFoundation follows http→https redirects it would otherwise drop
+  /// (issue #111). HTTPS and local URLs load natively, unchanged.
+  func makeAsset(for track: TrackItem, url: URL, isLocal: Bool) -> AVURLAsset {
+    let options = assetOptions(for: track, isLocal: isLocal)
+    guard !isLocal, let wrappedURL = TrackPlayerRedirectResolver.wrap(url) else {
+      return AVURLAsset(url: url, options: options)
+    }
+    redirectResolver.registerHeaders(httpHeaders(for: track), for: wrappedURL)
+    let asset = AVURLAsset(url: wrappedURL, options: options)
+    asset.resourceLoader.setDelegate(redirectResolver, queue: redirectResolver.queue)
+    return asset
+  }
+
   /// Creates a gapless-optimized AVPlayerItem with proper buffering configuration
   func createGaplessPlayerItem(for track: TrackItem, isPreload: Bool = false) -> AVPlayerItem? {
     let effectiveUrlString = DownloadManagerCore.shared.getEffectiveUrl(track: track)
@@ -427,7 +441,7 @@ extension TrackPlayerCore {
       asset = preloadedAsset
       NitroPlayerLogger.log("TrackPlayerCore", "🚀 Using preloaded asset for \(track.title)")
     } else {
-      asset = AVURLAsset(url: url, options: assetOptions(for: track, isLocal: isLocal))
+      asset = makeAsset(for: track, url: url, isLocal: isLocal)
     }
 
     let item = AVPlayerItem(asset: asset)
@@ -492,7 +506,7 @@ extension TrackPlayerCore {
           url = remoteUrl
         }
 
-        let asset = AVURLAsset(url: url, options: self.assetOptions(for: track, isLocal: isLocal))
+        let asset = self.makeAsset(for: track, url: url, isLocal: isLocal)
 
         asset.loadValuesAsynchronously(forKeys: Constants.preloadAssetKeys) { [weak self] in
           var allKeysLoaded = true

--- a/react-native-nitro-player/ios/core/TrackPlayerRedirectResolver.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerRedirectResolver.swift
@@ -1,0 +1,150 @@
+//
+//  TrackPlayerRedirectResolver.swift
+//  NitroPlayer
+//
+//  Created by Ritesh Shukla.
+//
+//  AVURLAsset does not reliably follow HTTP→HTTPS redirects: when a cleartext `http://`
+//  track URL answers with a 30x (e.g. a universal `308 → https://...` upgrade), AVFoundation
+//  silently drops the redirect and the item fails to load (issue #111). Unlike ExoPlayer's
+//  `setAllowCrossProtocolRedirects(true)`, AVFoundation exposes no such flag.
+//
+//  We work around it by giving such assets a sentinel URL scheme so AVFoundation has to ask
+//  this resource-loader delegate to load them. We then resolve the redirect chain ourselves
+//  with URLSession (which follows redirects) and hand AVFoundation a redirect to the final
+//  URL — after which it loads the media natively from the resolved location.
+//
+//  Only cleartext-`http` URLs are routed here. HTTPS assets are left untouched: AVFoundation
+//  follows same-scheme redirects on its own, so only the failing http path pays the extra
+//  resolution request. The app must still permit the initial cleartext connection via ATS
+//  (`NSAppTransportSecurity`); this delegate only fixes the redirect-following, not ATS.
+//
+
+import AVFoundation
+import Foundation
+
+final class TrackPlayerRedirectResolver: NSObject, AVAssetResourceLoaderDelegate {
+
+  /// Sentinel scheme prefix. A wrapped URL looks like `nitroredirect+http://host/path`.
+  private static let schemePrefix = "nitroredirect+"
+
+  /// Serial queue the resource-loader delegate methods (and our task bookkeeping) run on.
+  let queue = DispatchQueue(label: "com.nitroplayer.redirect", qos: .userInitiated)
+
+  private let session: URLSession
+
+  // In-flight resolution tasks, keyed by loading request, so a cancelled request cancels its
+  // task. Touched only on `queue` (delegate callbacks + the task completion is hopped onto it).
+  private var tasksByRequest: [ObjectIdentifier: URLSessionDataTask] = [:]
+
+  // Custom request headers (e.g. `Authorization`) per wrapped-URL, so the resolution request can
+  // authenticate when a server requires auth even to return the redirect. Written on the player
+  // queue (registerHeaders), read on `queue`; guarded by `headersLock`.
+  private var headersByURL: [String: [String: String]] = [:]
+  private let headersLock = NSLock()
+
+  override init() {
+    let config = URLSessionConfiguration.ephemeral
+    config.requestCachePolicy = .reloadIgnoringLocalCacheData
+    session = URLSession(configuration: config)
+    super.init()
+  }
+
+  // MARK: - URL wrapping
+
+  /// Wraps a cleartext-`http` URL in the sentinel scheme so AVFoundation routes it here.
+  /// Returns nil for anything else (https, file, custom schemes) — those load natively.
+  static func wrap(_ url: URL) -> URL? {
+    guard url.scheme?.lowercased() == "http",
+      var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    else { return nil }
+    components.scheme = schemePrefix + "http"
+    return components.url
+  }
+
+  /// Restores the real URL from a sentinel-wrapped URL.
+  private static func unwrap(_ url: URL) -> URL? {
+    guard let scheme = url.scheme?.lowercased(), scheme.hasPrefix(schemePrefix),
+      var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    else { return nil }
+    components.scheme = String(scheme.dropFirst(schemePrefix.count))
+    return components.url
+  }
+
+  // MARK: - Header registry
+
+  func registerHeaders(_ headers: [String: String]?, for wrappedURL: URL) {
+    guard let headers, !headers.isEmpty else { return }
+    headersLock.lock()
+    defer { headersLock.unlock() }
+    headersByURL[wrappedURL.absoluteString] = headers
+  }
+
+  /// Releases all registered headers. Call when the player is torn down.
+  func clear() {
+    headersLock.lock()
+    defer { headersLock.unlock() }
+    headersByURL.removeAll()
+  }
+
+  private func headers(for wrappedURL: URL) -> [String: String]? {
+    headersLock.lock()
+    defer { headersLock.unlock() }
+    return headersByURL[wrappedURL.absoluteString]
+  }
+
+  // MARK: - AVAssetResourceLoaderDelegate
+
+  func resourceLoader(
+    _ resourceLoader: AVAssetResourceLoader,
+    shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
+  ) -> Bool {
+    guard let wrappedURL = loadingRequest.request.url,
+      let realURL = Self.unwrap(wrappedURL)
+    else { return false }
+
+    var request = URLRequest(url: realURL)
+    // HEAD is enough: we only need `response.url` after URLSession follows the redirect chain.
+    // Even if the resolved endpoint rejects HEAD (405), the post-redirect URL is still reported.
+    request.httpMethod = "HEAD"
+    headers(for: wrappedURL)?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+    loadingRequest.request.allHTTPHeaderFields?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+
+    let key = ObjectIdentifier(loadingRequest)
+    let task = session.dataTask(with: request) { [weak self] _, response, error in
+      self?.queue.async {
+        guard let self else { return }
+        self.tasksByRequest.removeValue(forKey: key)
+        guard !loadingRequest.isCancelled, !loadingRequest.isFinished else { return }
+
+        if let error {
+          NitroPlayerLogger.log("TrackPlayerCore", "❌ Redirect resolution failed for \(realURL): \(error.localizedDescription)")
+          loadingRequest.finishLoading(with: error)
+          return
+        }
+
+        // `response.url` is the final URL after URLSession followed all redirects.
+        let finalURL = response?.url ?? realURL
+        if finalURL != realURL {
+          NitroPlayerLogger.log("TrackPlayerCore", "↪️ Resolved redirect \(realURL) → \(finalURL)")
+        }
+        var redirect = URLRequest(url: finalURL)
+        self.headers(for: wrappedURL)?.forEach { redirect.setValue($1, forHTTPHeaderField: $0) }
+        loadingRequest.redirect = redirect
+        loadingRequest.response = HTTPURLResponse(
+          url: finalURL, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: nil)
+        loadingRequest.finishLoading()
+      }
+    }
+    tasksByRequest[key] = task
+    task.resume()
+    return true
+  }
+
+  func resourceLoader(
+    _ resourceLoader: AVAssetResourceLoader,
+    didCancel loadingRequest: AVAssetResourceLoadingRequest
+  ) {
+    tasksByRequest.removeValue(forKey: ObjectIdentifier(loadingRequest))?.cancel()
+  }
+}


### PR DESCRIPTION
Fixes #111.

## Problem

A track URL served over `http://` that responds with a redirect to `https://` (e.g. a server-wide `308` upgrade) silently fails to play **on iOS**. Unlike ExoPlayer's `setAllowCrossProtocolRedirects(true)`, `AVURLAsset` exposes no cross-protocol-redirect flag and silently drops the redirect, so the player item never loads.

## Fix (iOS)

New `TrackPlayerRedirectResolver`, an `AVAssetResourceLoaderDelegate`:

- Only **cleartext `http://`** URLs are wrapped in a sentinel scheme (`nitroredirect+http://…`) so AVFoundation routes them to the delegate. `https://` and local files load natively — **no extra round-trip and no behavior change on the common path**.
- The delegate resolves the redirect chain with a `URLSession` HEAD (`response.url` is the final URL after redirects), then sets `loadingRequest.redirect` + a synthetic `302` so AVFoundation loads the **resolved** URL natively.
- Custom `extraPayload.headers` are forwarded on the resolution request and preserved on the real media load.
- Wired through a single `makeAsset(for:url:isLocal:)` helper used by both the playback and gapless-preload paths; cleared in `destroy()`. `redirectResolver` is a strong property on `TrackPlayerCore` (since `setDelegate` holds it weakly).

## Android

No code change needed — `AuthAwareHttpDataSourceFactory` already sets `setAllowCrossProtocolRedirects(true)` (v1.4.2+) and Media3 1.9.0 follows 307/308.

## App-side requirement (documented)

For any `http://` URL to work at all, the OS must permit the initial cleartext connection — the library cannot override this:

- **iOS** — `NSAppTransportSecurity` exception (or `NSAllowsArbitraryLoads`) in `Info.plist`.
- **Android** — `usesCleartextTraffic="true"` (default-off for API 28+).

Without it, the request never reaches the server and there is no redirect to follow. Documented in `docs/content/docs/types/index.mdx`.

## Verification

- `swiftc -typecheck` of the new resolver against the iOS SDK passes.
- Remaining edits reference only existing symbols.
- Not yet run: full `xcodebuild` of the example app against a live redirecting endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)