### PR TITLE
perf: window native player queue, order command dispatch, fix races

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -9,6 +9,9 @@ import React, { useEffect } from 'react';
 import { Platform, PermissionsAndroid, StatusBar } from 'react-native';
 import { TrackPlayer } from 'react-native-nitro-player';
 import AppNavigator from './src/navigation/AppNavigator';
+import BenchScreen from './src/screens/BenchScreen';
+
+const RUN_BENCH = false;
 
 void TrackPlayer.configure({
   androidAutoEnabled: true,
@@ -41,7 +44,7 @@ export default function App() {
   return (
     <>
       <StatusBar barStyle="dark-content" />
-      <AppNavigator />
+      {RUN_BENCH ? <BenchScreen /> : <AppNavigator />}
     </>
   );
 }

--- a/example/src/screens/BenchScreen.tsx
+++ b/example/src/screens/BenchScreen.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { PlayerQueue, TrackPlayer } from 'react-native-nitro-player';
 import type { TrackItem } from 'react-native-nitro-player';
 
@@ -100,9 +106,12 @@ export default function BenchScreen() {
         stateEvents.current++;
         if (off.stop) return;
         stormFetches++;
-        void TrackPlayer.getActualQueue().then((q) => {
-          stormTracks += q.length;
-        });
+        TrackPlayer.getActualQueue().then(
+          (q) => {
+            stormTracks += q.length;
+          },
+          () => {},
+        );
       });
       TrackPlayer.onChangeTrack(() => {
         trackEvents.current++;
@@ -136,23 +145,25 @@ export default function BenchScreen() {
   useEffect(() => {
     if (started.current) return;
     started.current = true;
-    const t = setTimeout(() => void run(), 3000);
+    const t = setTimeout(() => {
+      run();
+    }, 3000);
     return () => clearTimeout(t);
   }, [run]);
 
   return (
-    <View style={{ flex: 1, paddingTop: 60, paddingHorizontal: 12, backgroundColor: '#fff' }}>
+    <View style={styles.container}>
       <TouchableOpacity
         onPress={run}
         disabled={running}
-        style={{ padding: 14, backgroundColor: running ? '#999' : '#222', borderRadius: 8 }}>
-        <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600' }}>
+        style={[styles.button, running && styles.buttonDisabled]}>
+        <Text style={styles.buttonLabel}>
           {running ? 'Running…' : 'Run benchmark'}
         </Text>
       </TouchableOpacity>
-      <ScrollView style={{ marginTop: 16 }}>
+      <ScrollView style={styles.output}>
         {lines.map((l, i) => (
-          <Text key={i} style={{ fontFamily: 'Menlo', fontSize: 12, marginBottom: 3 }}>
+          <Text key={i} style={styles.line}>
             {l}
           </Text>
         ))}
@@ -160,3 +171,17 @@ export default function BenchScreen() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 60,
+    paddingHorizontal: 12,
+    backgroundColor: '#fff',
+  },
+  button: { padding: 14, backgroundColor: '#222', borderRadius: 8 },
+  buttonDisabled: { backgroundColor: '#999' },
+  buttonLabel: { color: '#fff', textAlign: 'center', fontWeight: '600' },
+  output: { marginTop: 16 },
+  line: { fontFamily: 'Menlo', fontSize: 12, marginBottom: 3 },
+});

--- a/example/src/screens/BenchScreen.tsx
+++ b/example/src/screens/BenchScreen.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { PlayerQueue, TrackPlayer } from 'react-native-nitro-player';
+import type { TrackItem } from 'react-native-nitro-player';
+
+const N = 500;
+const REPS = 20;
+const STORM_MS = 10000;
+const URL = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3';
+
+function makeTracks(): TrackItem[] {
+  const out: TrackItem[] = [];
+  for (let i = 0; i < N; i++) {
+    out.push({
+      id: `bench-${i}`,
+      title: `Bench Track ${i}`,
+      artist: 'Bench',
+      album: 'Bench Album',
+      duration: 180,
+      url: URL,
+      artwork: undefined,
+      extraPayload: undefined,
+    });
+  }
+  return out;
+}
+
+const now = () => Date.now();
+
+export default function BenchScreen() {
+  const [lines, setLines] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const push = useCallback((l: string) => {
+    console.log(`[BENCH] ${l}`);
+    setLines((p) => [...p, l]);
+  }, []);
+  const stateEvents = useRef(0);
+  const trackEvents = useRef(0);
+  const progressEvents = useRef(0);
+
+  const run = useCallback(async () => {
+    setLines([]);
+    setRunning(true);
+    try {
+      const tracks = makeTracks();
+
+      const pid = await PlayerQueue.createPlaylist(`bench-${now()}`);
+
+      let t = now();
+      await PlayerQueue.addTracksToPlaylist(pid, tracks);
+      push(`addTracks(${N})           ${now() - t} ms`);
+
+      t = now();
+      await PlayerQueue.loadPlaylist(pid);
+      push(`loadPlaylist(${N})        ${now() - t} ms`);
+
+      // getActualQueue round-trips
+      t = now();
+      let totalTracks = 0;
+      for (let i = 0; i < REPS; i++) {
+        const q = await TrackPlayer.getActualQueue();
+        totalTracks += q.length;
+      }
+      push(
+        `getActualQueue x${REPS}      ${now() - t} ms  (${totalTracks} items marshalled)`,
+      );
+
+      // skipToIndex
+      t = now();
+      for (let i = 0; i < REPS; i++) {
+        await TrackPlayer.skipToIndex((i * 17) % N);
+      }
+      push(`skipToIndex x${REPS}        ${now() - t} ms`);
+
+      // playNext (each triggers a native upcoming-queue rebuild)
+      await TrackPlayer.skipToIndex(0);
+      t = now();
+      for (let i = 0; i < REPS; i++) {
+        await TrackPlayer.playNext(`bench-${300 + i}`);
+      }
+      push(`playNext x${REPS}           ${now() - t} ms`);
+      await TrackPlayer.clearPlayNext();
+
+      // addToUpNext
+      t = now();
+      for (let i = 0; i < REPS; i++) {
+        await TrackPlayer.addToUpNext(`bench-${400 + i}`);
+      }
+      push(`addToUpNext x${REPS}        ${now() - t} ms`);
+      await TrackPlayer.clearUpNext();
+
+      // Event storm — what a mounted useActualQueue + useNowPlaying costs
+      stateEvents.current = 0;
+      trackEvents.current = 0;
+      progressEvents.current = 0;
+      let stormTracks = 0;
+      let stormFetches = 0;
+      const off = { stop: false };
+      TrackPlayer.onPlaybackStateChange(() => {
+        stateEvents.current++;
+        if (off.stop) return;
+        stormFetches++;
+        void TrackPlayer.getActualQueue().then((q) => {
+          stormTracks += q.length;
+        });
+      });
+      TrackPlayer.onChangeTrack(() => {
+        trackEvents.current++;
+      });
+      TrackPlayer.onPlaybackProgressChange(() => {
+        progressEvents.current++;
+      });
+
+      await TrackPlayer.skipToIndex(0);
+      await TrackPlayer.play();
+      await new Promise((r) => setTimeout(r, STORM_MS));
+      await TrackPlayer.pause();
+      off.stop = true;
+      await new Promise((r) => setTimeout(r, 500));
+
+      push(`--- ${STORM_MS / 1000}s playback storm ---`);
+      push(`onPlaybackStateChange     ${stateEvents.current} events`);
+      push(`onChangeTrack             ${trackEvents.current} events`);
+      push(`onPlaybackProgressChange  ${progressEvents.current} events`);
+      push(`queue refetches           ${stormFetches}`);
+      push(`tracks marshalled to JS   ${stormTracks}`);
+
+      await PlayerQueue.deletePlaylist(pid);
+    } catch (e) {
+      push(`ERROR ${String(e)}`);
+    }
+    setRunning(false);
+  }, [push]);
+
+  const started = useRef(false);
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    const t = setTimeout(() => void run(), 3000);
+    return () => clearTimeout(t);
+  }, [run]);
+
+  return (
+    <View style={{ flex: 1, paddingTop: 60, paddingHorizontal: 12, backgroundColor: '#fff' }}>
+      <TouchableOpacity
+        onPress={run}
+        disabled={running}
+        style={{ padding: 14, backgroundColor: running ? '#999' : '#222', borderRadius: 8 }}>
+        <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600' }}>
+          {running ? 'Running…' : 'Run benchmark'}
+        </Text>
+      </TouchableOpacity>
+      <ScrollView style={{ marginTop: 16 }}>
+        {lines.map((l, i) => (
+          <Text key={i} style={{ fontFamily: 'Menlo', fontSize: 12, marginBottom: 3 }}>
+            {l}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
@@ -113,7 +113,10 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
      * Enqueued synchronously on the player looper so a `loadPlaylist()` followed by
      * `play()` from JS cannot be reordered — see HybridTrackPlayer.enqueue.
      */
-    override fun loadPlaylist(playlistId: String, index: Double?): Promise<Unit> {
+    override fun loadPlaylist(
+        playlistId: String,
+        index: Double?,
+    ): Promise<Unit> {
         val startIndex = index?.toInt()
         val promise = Promise<Unit>()
         core.enqueue {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
@@ -8,7 +8,7 @@ import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.NullType
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.nitroplayer.core.TrackPlayerCore
-import com.margelo.nitro.nitroplayer.core.loadPlaylist
+import com.margelo.nitro.nitroplayer.core.loadPlaylistOnQueue
 import com.margelo.nitro.nitroplayer.core.updatePlaylist
 import com.margelo.nitro.nitroplayer.playlist.PlaylistManager
 import java.util.UUID
@@ -109,13 +109,21 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
 
     // ── Playback control ──────────────────────────────────────────────────────
 
-    override fun loadPlaylist(playlistId: String, index: Double?): Promise<Unit> =
-        Promise.async {
-            val startIndex = index?.toInt()
-            val loaded = playlistManager.loadPlaylist(playlistId, startIndex)
-            if (!loaded) return@async
-            core.loadPlaylist(playlistId, startIndex)
+    /**
+     * Enqueued synchronously on the player looper so a `loadPlaylist()` followed by
+     * `play()` from JS cannot be reordered — see HybridTrackPlayer.enqueue.
+     */
+    override fun loadPlaylist(playlistId: String, index: Double?): Promise<Unit> {
+        val startIndex = index?.toInt()
+        val promise = Promise<Unit>()
+        core.enqueue {
+            if (playlistManager.loadPlaylist(playlistId, startIndex)) {
+                core.loadPlaylistOnQueue(playlistId, startIndex)
+            }
+            promise.resolve(Unit)
         }
+        return promise
+    }
 
     override fun getCurrentPlaylistId(): Variant_NullType_String {
         val id = core.getCurrentPlaylistId()

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridTrackPlayer.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridTrackPlayer.kt
@@ -7,35 +7,30 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.nitroplayer.core.TrackPlayerCore
-import com.margelo.nitro.nitroplayer.core.addToUpNext
-import com.margelo.nitro.nitroplayer.core.clearPlayNext
-import com.margelo.nitro.nitroplayer.core.clearUpNext
-import com.margelo.nitro.nitroplayer.core.configure
-import com.margelo.nitro.nitroplayer.core.getActualQueue
-import com.margelo.nitro.nitroplayer.core.getCurrentTrackIndex
-import com.margelo.nitro.nitroplayer.core.getNextTracks
-import com.margelo.nitro.nitroplayer.core.getPlayBackSpeed
-import com.margelo.nitro.nitroplayer.core.getPlayNextQueue
+import com.margelo.nitro.nitroplayer.core.addToUpNextInternal
+import com.margelo.nitro.nitroplayer.core.clearPlayNextOnQueue
+import com.margelo.nitro.nitroplayer.core.clearUpNextOnQueue
+import com.margelo.nitro.nitroplayer.core.configureOnQueue
+import com.margelo.nitro.nitroplayer.core.getActualQueueInternal
+import com.margelo.nitro.nitroplayer.core.getNextTracksInternal
 import com.margelo.nitro.nitroplayer.core.getRepeatMode
-import com.margelo.nitro.nitroplayer.core.getState
-import com.margelo.nitro.nitroplayer.core.getTracksById
-import com.margelo.nitro.nitroplayer.core.getTracksNeedingUrls
-import com.margelo.nitro.nitroplayer.core.getUpNextQueue
-import com.margelo.nitro.nitroplayer.core.pause
-import com.margelo.nitro.nitroplayer.core.play
-import com.margelo.nitro.nitroplayer.core.playNext
-import com.margelo.nitro.nitroplayer.core.playSong
-import com.margelo.nitro.nitroplayer.core.removeFromPlayNext
-import com.margelo.nitro.nitroplayer.core.removeFromUpNext
-import com.margelo.nitro.nitroplayer.core.reorderTemporaryTrack
-import com.margelo.nitro.nitroplayer.core.seek
-import com.margelo.nitro.nitroplayer.core.setPlayBackSpeed
-import com.margelo.nitro.nitroplayer.core.setRepeatMode
-import com.margelo.nitro.nitroplayer.core.setVolume
-import com.margelo.nitro.nitroplayer.core.skipToIndex
-import com.margelo.nitro.nitroplayer.core.skipToNext
-import com.margelo.nitro.nitroplayer.core.skipToPrevious
-import com.margelo.nitro.nitroplayer.core.updateTracks
+import com.margelo.nitro.nitroplayer.core.getStateInternal
+import com.margelo.nitro.nitroplayer.core.getTracksNeedingUrlsInternal
+import com.margelo.nitro.nitroplayer.core.pauseOnQueue
+import com.margelo.nitro.nitroplayer.core.playNextInternal
+import com.margelo.nitro.nitroplayer.core.playOnQueue
+import com.margelo.nitro.nitroplayer.core.playSongInternal
+import com.margelo.nitro.nitroplayer.core.removeFromPlayNextOnQueue
+import com.margelo.nitro.nitroplayer.core.removeFromUpNextOnQueue
+import com.margelo.nitro.nitroplayer.core.reorderTemporaryTrackOnQueue
+import com.margelo.nitro.nitroplayer.core.seekOnQueue
+import com.margelo.nitro.nitroplayer.core.setPlayBackSpeedOnQueue
+import com.margelo.nitro.nitroplayer.core.setRepeatModeOnQueue
+import com.margelo.nitro.nitroplayer.core.setVolumeOnQueue
+import com.margelo.nitro.nitroplayer.core.skipToIndexInternal
+import com.margelo.nitro.nitroplayer.core.skipToNextOnQueue
+import com.margelo.nitro.nitroplayer.core.skipToPreviousOnQueue
+import com.margelo.nitro.nitroplayer.core.updateTracksOnQueue
 
 @DoNotStrip
 @Keep
@@ -52,79 +47,100 @@ class HybridTrackPlayer : HybridTrackPlayerSpec() {
         core = TrackPlayerCore.getInstance(context)
     }
 
+    // ── Ordered dispatch ──────────────────────────────────────────────────────
+    //
+    // `Promise.async { … }` launches an unordered coroutine, so the hop onto the player
+    // looper happened at an arbitrary later point: two calls made in order from JS could
+    // reach the player in reverse order (play-then-pause landing as pause-then-play).
+    // `core.enqueue` appends synchronously, on the JS thread at call time, so execution
+    // order equals JS call order.
+
+    private fun <T> enqueue(block: () -> T): Promise<T> {
+        val promise = Promise<T>()
+        core.enqueue {
+            try {
+                promise.resolve(block())
+            } catch (e: Throwable) {
+                promise.reject(e)
+            }
+        }
+        return promise
+    }
+
     // ── Playback ─────────────────────────────────────────────────────────────
 
-    override fun play(): Promise<Unit> = Promise.async { core.play() }
+    override fun play(): Promise<Unit> = enqueue { core.playOnQueue() }
 
-    override fun pause(): Promise<Unit> = Promise.async { core.pause() }
+    override fun pause(): Promise<Unit> = enqueue { core.pauseOnQueue() }
 
-    override fun seek(position: Double): Promise<Unit> = Promise.async { core.seek(position) }
+    override fun seek(position: Double): Promise<Unit> = enqueue { core.seekOnQueue(position) }
 
-    override fun skipToNext(): Promise<Unit> = Promise.async { core.skipToNext() }
+    override fun skipToNext(): Promise<Unit> = enqueue { core.skipToNextOnQueue() }
 
-    override fun skipToPrevious(): Promise<Unit> = Promise.async { core.skipToPrevious() }
+    override fun skipToPrevious(): Promise<Unit> = enqueue { core.skipToPreviousOnQueue() }
 
     override fun playSong(
         songId: String,
         fromPlaylist: String?,
-    ): Promise<Unit> = Promise.async { core.playSong(songId, fromPlaylist) }
+    ): Promise<Unit> = enqueue { core.playSongInternal(songId, fromPlaylist) }
 
-    override fun skipToIndex(index: Double): Promise<Boolean> = Promise.async { core.skipToIndex(index.toInt()) }
+    override fun skipToIndex(index: Double): Promise<Boolean> = enqueue { core.skipToIndexInternal(index.toInt()) }
 
-    override fun setRepeatMode(mode: RepeatMode): Promise<Unit> = Promise.async { core.setRepeatMode(mode) }
+    override fun setRepeatMode(mode: RepeatMode): Promise<Unit> = enqueue { core.setRepeatModeOnQueue(mode) }
 
     override fun getRepeatMode(): RepeatMode = core.getRepeatMode()
 
-    override fun setVolume(volume: Double): Promise<Unit> = Promise.async { core.setVolume(volume) }
+    override fun setVolume(volume: Double): Promise<Unit> = enqueue { core.setVolumeOnQueue(volume) }
 
-    override fun configure(config: PlayerConfig): Promise<Unit> = Promise.async { core.configure(config) }
+    override fun configure(config: PlayerConfig): Promise<Unit> = enqueue { core.configureOnQueue(config) }
 
     // ── Queue / state reads ───────────────────────────────────────────────────
 
-    override fun getActualQueue(): Promise<Array<TrackItem>> = Promise.async { core.getActualQueue().toTypedArray() }
+    override fun getActualQueue(): Promise<Array<TrackItem>> = enqueue { core.getActualQueueInternal().toTypedArray() }
 
-    override fun getState(): Promise<PlayerState> = Promise.async { core.getState() }
+    override fun getState(): Promise<PlayerState> = enqueue { core.getStateInternal() }
 
-    override fun getTracksById(trackIds: Array<String>): Promise<Array<TrackItem>> = Promise.async { core.getTracksById(trackIds.toList()).toTypedArray() }
+    override fun getTracksById(trackIds: Array<String>): Promise<Array<TrackItem>> =
+        enqueue { core.getPlaylistManager().getTracksById(trackIds.toList()).toTypedArray() }
 
-    override fun getTracksNeedingUrls(): Promise<Array<TrackItem>> = Promise.async { core.getTracksNeedingUrls().toTypedArray() }
+    override fun getTracksNeedingUrls(): Promise<Array<TrackItem>> = enqueue { core.getTracksNeedingUrlsInternal().toTypedArray() }
 
-    override fun getNextTracks(count: Double): Promise<Array<TrackItem>> = Promise.async { core.getNextTracks(count.toInt()).toTypedArray() }
+    override fun getNextTracks(count: Double): Promise<Array<TrackItem>> = enqueue { core.getNextTracksInternal(count.toInt()).toTypedArray() }
 
-    override fun getCurrentTrackIndex(): Promise<Double> = Promise.async { core.getCurrentTrackIndex().toDouble() }
+    override fun getCurrentTrackIndex(): Promise<Double> = enqueue { core.currentTrackIndex.toDouble() }
 
     // ── URL updates ───────────────────────────────────────────────────────────
 
-    override fun updateTracks(tracks: Array<TrackItem>): Promise<Unit> = Promise.async { core.updateTracks(tracks.toList()) }
+    override fun updateTracks(tracks: Array<TrackItem>): Promise<Unit> = enqueue { core.updateTracksOnQueue(tracks.toList()) }
 
     // ── Temporary queue ───────────────────────────────────────────────────────
 
-    override fun addToUpNext(trackId: String): Promise<Unit> = Promise.async { core.addToUpNext(trackId) }
+    override fun addToUpNext(trackId: String): Promise<Unit> = enqueue { core.addToUpNextInternal(trackId) }
 
-    override fun playNext(trackId: String): Promise<Unit> = Promise.async { core.playNext(trackId) }
+    override fun playNext(trackId: String): Promise<Unit> = enqueue { core.playNextInternal(trackId) }
 
-    override fun removeFromPlayNext(trackId: String): Promise<Boolean> = Promise.async { core.removeFromPlayNext(trackId) }
+    override fun removeFromPlayNext(trackId: String): Promise<Boolean> = enqueue { core.removeFromPlayNextOnQueue(trackId) }
 
-    override fun removeFromUpNext(trackId: String): Promise<Boolean> = Promise.async { core.removeFromUpNext(trackId) }
+    override fun removeFromUpNext(trackId: String): Promise<Boolean> = enqueue { core.removeFromUpNextOnQueue(trackId) }
 
-    override fun clearPlayNext(): Promise<Unit> = Promise.async { core.clearPlayNext() }
+    override fun clearPlayNext(): Promise<Unit> = enqueue { core.clearPlayNextOnQueue() }
 
-    override fun clearUpNext(): Promise<Unit> = Promise.async { core.clearUpNext() }
+    override fun clearUpNext(): Promise<Unit> = enqueue { core.clearUpNextOnQueue() }
 
     override fun reorderTemporaryTrack(
         trackId: String,
         newIndex: Double,
-    ): Promise<Boolean> = Promise.async { core.reorderTemporaryTrack(trackId, newIndex.toInt()) }
+    ): Promise<Boolean> = enqueue { core.reorderTemporaryTrackOnQueue(trackId, newIndex.toInt()) }
 
-    override fun getPlayNextQueue(): Promise<Array<TrackItem>> = Promise.async { core.getPlayNextQueue().toTypedArray() }
+    override fun getPlayNextQueue(): Promise<Array<TrackItem>> = enqueue { core.playNextStack.toTypedArray() }
 
-    override fun getUpNextQueue(): Promise<Array<TrackItem>> = Promise.async { core.getUpNextQueue().toTypedArray() }
+    override fun getUpNextQueue(): Promise<Array<TrackItem>> = enqueue { core.upNextQueue.toTypedArray() }
 
     // ── Playback speed ────────────────────────────────────────────────────────
 
-    override fun setPlaybackSpeed(speed: Double): Promise<Unit> = Promise.async { core.setPlayBackSpeed(speed) }
+    override fun setPlaybackSpeed(speed: Double): Promise<Unit> = enqueue { core.setPlayBackSpeedOnQueue(speed) }
 
-    override fun getPlaybackSpeed(): Promise<Double> = Promise.async { core.getPlayBackSpeed() }
+    override fun getPlaybackSpeed(): Promise<Double> = enqueue { if (core.isExoInitialized) core.exo.getPlaybackSpeed().toDouble() else 1.0 }
 
     // ── Android Auto ──────────────────────────────────────────────────────────
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridTrackPlayer.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridTrackPlayer.kt
@@ -100,8 +100,7 @@ class HybridTrackPlayer : HybridTrackPlayerSpec() {
 
     override fun getState(): Promise<PlayerState> = enqueue { core.getStateInternal() }
 
-    override fun getTracksById(trackIds: Array<String>): Promise<Array<TrackItem>> =
-        enqueue { core.getPlaylistManager().getTracksById(trackIds.toList()).toTypedArray() }
+    override fun getTracksById(trackIds: Array<String>): Promise<Array<TrackItem>> = enqueue { core.getPlaylistManager().getTracksById(trackIds.toList()).toTypedArray() }
 
     override fun getTracksNeedingUrls(): Promise<Array<TrackItem>> = enqueue { core.getTracksNeedingUrlsInternal().toTypedArray() }
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -104,18 +104,22 @@ class TrackPlayerCore private constructor(
     internal var lastCastWaitTrackId: String? = null
 
     // ── Progress & playlist-update runnables ───────────────────────────────
+    /**
+     * Emits progress once per second while actually playing (matching iOS), instead of
+     * four times a second regardless of state. A paused player has nothing to report,
+     * and every tick is a JS callback that re-renders every `useNowPlaying` consumer.
+     * A seek still reports immediately via `onPositionDiscontinuity`.
+     */
     internal val progressUpdateRunnable =
         object : Runnable {
             override fun run() {
-                if (::exo.isInitialized &&
-                    exo.playbackState != androidx.media3.common.Player.STATE_IDLE
-                ) {
+                if (::exo.isInitialized && exo.isPlaying) {
                     val pos = exo.currentPosition / 1000.0
                     val dur = if (exo.duration > 0) exo.duration / 1000.0 else 0.0
                     notifyPlaybackProgress(pos, dur, if (isManuallySeeked) true else null)
                     isManuallySeeked = false
                 }
-                playerHandler.postDelayed(this, 250)
+                playerHandler.postDelayed(this, PROGRESS_INTERVAL_MS)
             }
         }
 
@@ -192,6 +196,8 @@ class TrackPlayerCore private constructor(
 
     // ── Singleton ──────────────────────────────────────────────────────────
     companion object {
+        internal const val PROGRESS_INTERVAL_MS = 1000L
+
         @Volatile
         @Suppress("ktlint:standard:property-naming")
         private var INSTANCE: TrackPlayerCore? = null
@@ -206,8 +212,18 @@ class TrackPlayerCore private constructor(
         // Defer service start/bind to the main thread so it doesn't run
         // synchronously on the JNI thread during HybridObject creation.
         handler.post {
-            val intent = Intent(context, NitroPlayerPlaybackService::class.java)
-            context.startService(intent)
+            // startService throws BackgroundServiceStartNotAllowedException on Android 12+
+            // when the process is in the background — which is exactly what happens when JS
+            // loads the module from a headless/backgrounded start. It is only here to keep
+            // the service alive across unbind; BIND_AUTO_CREATE below already creates it,
+            // and the service promotes itself to foreground once playback starts.
+            try {
+                context.startService(Intent(context, NitroPlayerPlaybackService::class.java))
+            } catch (e: Exception) {
+                NitroPlayerLogger.log("TrackPlayerCore") {
+                    "startService skipped (app in background): ${e.message}"
+                }
+            }
 
             val bindIntent =
                 Intent(context, NitroPlayerPlaybackService::class.java).apply {
@@ -218,6 +234,58 @@ class TrackPlayerCore private constructor(
     }
 
     // ── Coroutine bridge to player looper (main thread) ────────────────────
+
+    // ── Ordered command dispatch ───────────────────────────────────────────
+    //
+    // `Promise.async { … }` launches an unordered coroutine, so the hop onto the
+    // player looper used to happen at an arbitrary later point: two calls made in
+    // order from JS could reach the player in reverse order (play-then-pause landing
+    // as pause-then-play). `enqueue` appends to a queue synchronously, on the JS
+    // thread at call time, so execution order equals JS call order — including for
+    // commands issued before the playback service has bound.
+
+    private val pendingCommands = ArrayDeque<() -> Unit>()
+    private var commandsDraining = false
+
+    /**
+     * Runs [block] on the player looper, preserving the order in which callers
+     * enqueued. Safe to call before the service binds — commands buffer until then.
+     */
+    internal fun enqueue(block: () -> Unit) {
+        synchronized(pendingCommands) {
+            pendingCommands.addLast(block)
+            if (commandsDraining) return
+            if (!::playerHandler.isInitialized) return
+            commandsDraining = true
+        }
+        playerHandler.post { drainCommands() }
+    }
+
+    private fun drainCommands() {
+        while (true) {
+            val next =
+                synchronized(pendingCommands) {
+                    val head = pendingCommands.removeFirstOrNull()
+                    if (head == null) commandsDraining = false
+                    head
+                } ?: return
+            next()
+        }
+    }
+
+    /** Called once the player looper exists — flushes anything queued before binding. */
+    internal fun startCommandDraining() {
+        val shouldPost =
+            synchronized(pendingCommands) {
+                if (commandsDraining || pendingCommands.isEmpty()) {
+                    false
+                } else {
+                    commandsDraining = true
+                    true
+                }
+            }
+        if (shouldPost) playerHandler.post { drainCommands() }
+    }
 
     internal suspend fun <T> withPlayerContext(block: () -> T): T {
         // Wait until the service is bound and player is initialized

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -94,6 +94,7 @@ class TrackPlayerCore private constructor(
         ListenerRegistry<(com.margelo.nitro.nitroplayer.CastState, String?) -> Unit>()
 
     // ── Google Cast ──────────────────────────────────────────────────────────
+
     /** Set once the playback service has a usable CastContext; null when Cast is unavailable. */
     internal var castSessionController: com.margelo.nitro.nitroplayer.media.CastSessionController? = null
 
@@ -104,6 +105,7 @@ class TrackPlayerCore private constructor(
     internal var lastCastWaitTrackId: String? = null
 
     // ── Progress & playlist-update runnables ───────────────────────────────
+
     /**
      * Emits progress once per second while actually playing (matching iOS), instead of
      * four times a second regardless of state. A paused player has nothing to report,
@@ -159,7 +161,8 @@ class TrackPlayerCore private constructor(
                     }
                     try {
                         context.unbindService(this)
-                    } catch (_: Exception) {}
+                    } catch (_: Exception) {
+                    }
                     serviceBound = false
                     if (rebindAttempts < 3) {
                         rebindAttempts++
@@ -324,13 +327,15 @@ class TrackPlayerCore private constructor(
             }
         }
         scope.cancel()
-        com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory.clear()
+        com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory
+            .clear()
         // Do NOT stop the service — it owns the player.
         // Unbind so Android can clean up if needed.
         if (serviceBound) {
             try {
                 context.unbindService(serviceConnection)
-            } catch (_: Exception) {}
+            } catch (_: Exception) {
+            }
             serviceBound = false
         }
     }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
@@ -57,6 +57,16 @@ internal class TrackPlayerEventListener(
                 if (newIdx >= 0 && newIdx != currentTrackIndex) currentTrackIndex = newIdx
             }
 
+            // Top up the windowed timeline — the item we just left freed a slot.
+            // Only when it is actually short: rebuildQueueFromCurrentPosition can fall
+            // into the substitute-jump path (setMediaItems), which re-enters this very
+            // callback. The length check makes any such re-entry a no-op and terminate.
+            if (mediaItem != null &&
+                exo.mediaItemCount - exo.currentMediaItemIndex - 1 < QUEUE_WINDOW_SIZE
+            ) {
+                rebuildQueueFromCurrentPosition()
+            }
+
             val track = getCurrentTrack() ?: return
             val r =
                 when (reason) {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
@@ -45,42 +45,42 @@ internal fun TrackPlayerCore.skipToNextOnQueue() {
 suspend fun TrackPlayerCore.skipToPrevious() = withPlayerContext { skipToPreviousOnQueue() }
 
 internal fun TrackPlayerCore.skipToPreviousOnQueue() {
-        val currentPosition = exo.currentPosition
-        when {
-            currentPosition > 2000 -> {
-                exo.seekTo(0)
-            }
-
-            currentTemporaryType != TrackPlayerCore.TemporaryType.NONE -> {
-                val trackId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
-                if (trackId != null) {
-                    when (currentTemporaryType) {
-                        TrackPlayerCore.TemporaryType.PLAY_NEXT -> {
-                            val idx = playNextStack.indexOfFirst { it.id == trackId }
-                            if (idx >= 0) playNextStack.removeAt(idx)
-                        }
-
-                        TrackPlayerCore.TemporaryType.UP_NEXT -> {
-                            val idx = upNextQueue.indexOfFirst { it.id == trackId }
-                            if (idx >= 0) upNextQueue.removeAt(idx)
-                        }
-
-                        else -> {}
-                    }
-                }
-                currentTemporaryType = TrackPlayerCore.TemporaryType.NONE
-                playFromIndexInternal(currentTrackIndex)
-            }
-
-            currentTrackIndex > 0 -> {
-                playFromIndexInternal(currentTrackIndex - 1)
-            }
-
-            else -> {
-                exo.seekTo(0)
-            }
+    val currentPosition = exo.currentPosition
+    when {
+        currentPosition > 2000 -> {
+            exo.seekTo(0)
         }
-        checkUpcomingTracksForUrls(lookaheadCount)
+
+        currentTemporaryType != TrackPlayerCore.TemporaryType.NONE -> {
+            val trackId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
+            if (trackId != null) {
+                when (currentTemporaryType) {
+                    TrackPlayerCore.TemporaryType.PLAY_NEXT -> {
+                        val idx = playNextStack.indexOfFirst { it.id == trackId }
+                        if (idx >= 0) playNextStack.removeAt(idx)
+                    }
+
+                    TrackPlayerCore.TemporaryType.UP_NEXT -> {
+                        val idx = upNextQueue.indexOfFirst { it.id == trackId }
+                        if (idx >= 0) upNextQueue.removeAt(idx)
+                    }
+
+                    else -> {}
+                }
+            }
+            currentTemporaryType = TrackPlayerCore.TemporaryType.NONE
+            playFromIndexInternal(currentTrackIndex)
+        }
+
+        currentTrackIndex > 0 -> {
+            playFromIndexInternal(currentTrackIndex - 1)
+        }
+
+        else -> {
+            exo.seekTo(0)
+        }
+    }
+    checkUpcomingTracksForUrls(lookaheadCount)
 }
 
 suspend fun TrackPlayerCore.setRepeatMode(mode: RepeatMode) = withPlayerContext { setRepeatModeOnQueue(mode) }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
@@ -15,26 +15,36 @@ import com.margelo.nitro.nitroplayer.media.NitroPlayerPlaybackService
  * via withPlayerContext.
  */
 
-suspend fun TrackPlayerCore.play() = withPlayerContext { exo.play() }
+suspend fun TrackPlayerCore.play() = withPlayerContext { playOnQueue() }
 
-suspend fun TrackPlayerCore.pause() = withPlayerContext { exo.pause() }
+internal fun TrackPlayerCore.playOnQueue() = exo.play()
 
-suspend fun TrackPlayerCore.seek(position: Double) =
-    withPlayerContext {
-        isManuallySeeked = true
-        exo.seekTo((position * 1000).toLong())
+suspend fun TrackPlayerCore.pause() = withPlayerContext { pauseOnQueue() }
+
+internal fun TrackPlayerCore.pauseOnQueue() = exo.pause()
+
+suspend fun TrackPlayerCore.seek(position: Double) = withPlayerContext { seekOnQueue(position) }
+
+internal fun TrackPlayerCore.seekOnQueue(position: Double) {
+    isManuallySeeked = true
+    exo.seekTo((position * 1000).toLong())
+}
+
+suspend fun TrackPlayerCore.skipToNext() = withPlayerContext { skipToNextOnQueue() }
+
+internal fun TrackPlayerCore.skipToNextOnQueue() {
+    // The timeline is windowed, so hasNextMediaItem() is not the logical answer —
+    // top up first when more tracks remain in currentTracks / the temp queues.
+    if (!exo.hasNextMediaItem()) rebuildQueueFromCurrentPosition()
+    if (exo.hasNextMediaItem()) {
+        exo.seekToNext()
+        checkUpcomingTracksForUrls(lookaheadCount)
     }
+}
 
-suspend fun TrackPlayerCore.skipToNext() =
-    withPlayerContext {
-        if (exo.hasNextMediaItem()) {
-            exo.seekToNext()
-            checkUpcomingTracksForUrls(lookaheadCount)
-        }
-    }
+suspend fun TrackPlayerCore.skipToPrevious() = withPlayerContext { skipToPreviousOnQueue() }
 
-suspend fun TrackPlayerCore.skipToPrevious() =
-    withPlayerContext {
+internal fun TrackPlayerCore.skipToPreviousOnQueue() {
         val currentPosition = exo.currentPosition
         when {
             currentPosition > 2000 -> {
@@ -71,34 +81,37 @@ suspend fun TrackPlayerCore.skipToPrevious() =
             }
         }
         checkUpcomingTracksForUrls(lookaheadCount)
-    }
+}
 
-suspend fun TrackPlayerCore.setRepeatMode(mode: RepeatMode) =
-    withPlayerContext {
-        currentRepeatMode = mode
-        exo.setRepeatMode(
-            when (mode) {
-                RepeatMode.TRACK -> Player.REPEAT_MODE_ONE
-                else -> Player.REPEAT_MODE_OFF
-            },
-        )
-    }
+suspend fun TrackPlayerCore.setRepeatMode(mode: RepeatMode) = withPlayerContext { setRepeatModeOnQueue(mode) }
+
+internal fun TrackPlayerCore.setRepeatModeOnQueue(mode: RepeatMode) {
+    currentRepeatMode = mode
+    exo.setRepeatMode(
+        when (mode) {
+            RepeatMode.TRACK -> Player.REPEAT_MODE_ONE
+            else -> Player.REPEAT_MODE_OFF
+        },
+    )
+}
 
 fun TrackPlayerCore.getRepeatMode(): RepeatMode = currentRepeatMode
 
-suspend fun TrackPlayerCore.setVolume(volume: Double) =
-    withPlayerContext {
-        val clamped = volume.coerceIn(0.0, 100.0)
-        exo.setVolume((clamped / 100.0).toFloat())
-    }
+suspend fun TrackPlayerCore.setVolume(volume: Double) = withPlayerContext { setVolumeOnQueue(volume) }
 
-suspend fun TrackPlayerCore.configure(config: PlayerConfig) =
-    withPlayerContext {
-        config.androidAutoEnabled?.let { NitroPlayerMediaBrowserService.isAndroidAutoEnabled = it }
-        config.lookaheadCount?.let { lookaheadCount = it.toInt() }
-        config.androidNotificationIcon?.let { NitroPlayerPlaybackService.notificationSmallIconResName = it }
-        mediaSessionManager?.configure(config.androidAutoEnabled, config.carPlayEnabled, config.showInNotification)
-    }
+internal fun TrackPlayerCore.setVolumeOnQueue(volume: Double) {
+    val clamped = volume.coerceIn(0.0, 100.0)
+    exo.setVolume((clamped / 100.0).toFloat())
+}
+
+suspend fun TrackPlayerCore.configure(config: PlayerConfig) = withPlayerContext { configureOnQueue(config) }
+
+internal fun TrackPlayerCore.configureOnQueue(config: PlayerConfig) {
+    config.androidAutoEnabled?.let { NitroPlayerMediaBrowserService.isAndroidAutoEnabled = it }
+    config.lookaheadCount?.let { lookaheadCount = it.toInt() }
+    config.androidNotificationIcon?.let { NitroPlayerPlaybackService.notificationSmallIconResName = it }
+    mediaSessionManager?.configure(config.androidAutoEnabled, config.carPlayEnabled, config.showInNotification)
+}
 
 suspend fun TrackPlayerCore.playSong(
     songId: String,
@@ -181,11 +194,12 @@ internal fun TrackPlayerCore.emitStateChange(reason: Reason? = null) {
 
 // ── Playback speed ────────────────────────────────────────────────────────
 
-suspend fun TrackPlayerCore.setPlayBackSpeed(speed: Double) =
-    withPlayerContext {
-        if (speed <= 0.0) throw IllegalArgumentException("Speed must be greater than 0")
-        if (isExoInitialized) exo.setPlaybackSpeed(speed.toFloat())
-    }
+suspend fun TrackPlayerCore.setPlayBackSpeed(speed: Double) = withPlayerContext { setPlayBackSpeedOnQueue(speed) }
+
+internal fun TrackPlayerCore.setPlayBackSpeedOnQueue(speed: Double) {
+    if (speed <= 0.0) throw IllegalArgumentException("Speed must be greater than 0")
+    if (isExoInitialized) exo.setPlaybackSpeed(speed.toFloat())
+}
 
 suspend fun TrackPlayerCore.getPlayBackSpeed(): Double =
     withPlayerContext {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueue.kt
@@ -59,7 +59,9 @@ internal fun TrackPlayerCore.getStateInternal(): PlayerState {
         totalDuration = duration,
         currentState = state,
         currentPlaylistId = currentPlaylistId?.let { Variant_NullType_String.create(it) },
-        currentIndex = if (exo.currentMediaItemIndex >= 0) exo.currentMediaItemIndex.toDouble() else -1.0,
+        // Playlist index, not the index inside ExoPlayer's (windowed, rebuilt-from-N)
+        // timeline — that reads 0 after any jump. Matches iOS and the documented contract.
+        currentIndex = if (currentTrackIndex >= 0) currentTrackIndex.toDouble() else -1.0,
         currentPlayingType = playingType,
     )
 }
@@ -128,7 +130,7 @@ internal fun TrackPlayerCore.getActualQueueInternal(): List<TrackItem> {
 
 suspend fun TrackPlayerCore.skipToIndex(index: Int): Boolean = withPlayerContext { skipToIndexInternal(index) }
 
-private fun TrackPlayerCore.skipToIndexInternal(index: Int): Boolean {
+internal fun TrackPlayerCore.skipToIndexInternal(index: Int): Boolean {
     if (!isExoInitialized) return false
     val actualQueue = getActualQueueInternal()
     if (index < 0 || index >= actualQueue.size) return false

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -37,6 +37,14 @@ internal fun TrackPlayerCore.castableUpcoming(tracks: List<TrackItem>): List<Tra
     return result
 }
 
+/**
+ * Upcoming MediaItems kept materialized behind the current one. The logical queue
+ * (currentTracks + temp lists) stays complete; only ExoPlayer's timeline is windowed,
+ * and it is topped up on every item transition. Building a MediaItem is not free —
+ * each one resolves the effective URL, which used to stat() the download record.
+ */
+internal const val QUEUE_WINDOW_SIZE = 4
+
 internal fun TrackPlayerCore.mediaIdFor(track: TrackItem): String {
     val playlistId = currentPlaylistId ?: ""
     return if (playlistId.isNotEmpty()) "$playlistId:${track.id}" else track.id
@@ -70,8 +78,9 @@ internal fun TrackPlayerCore.rebuildQueueAndPlayFromIndex(index: Int) {
         return
     }
 
+    val windowEnd = minOf(index + 1 + QUEUE_WINDOW_SIZE, currentTracks.size)
     val mediaItems =
-        currentTracks.subList(index, currentTracks.size).map { track ->
+        currentTracks.subList(index, windowEnd).map { track ->
             makeMediaItem(track, mediaIdFor(track))
         }
 
@@ -131,12 +140,32 @@ internal fun TrackPlayerCore.rebuildQueueFromCurrentPosition() {
         }
     }
 
-    val newMediaItems = newQueueTracks.map { makeMediaItem(it, mediaIdFor(it)) }
-
-    if (exo.mediaItemCount > currentIndex + 1) {
-        exo.removeMediaItems(currentIndex + 1, exo.mediaItemCount)
+    // Window the materialized timeline; onMediaItemTransition tops it back up.
+    // NOT while casting: the receiver holds the whole queue (rebuildQueueAndPlayFromIndex
+    // loads it unwindowed), so truncating here would cut it down to the window size.
+    if (!isCastingField && newQueueTracks.size > QUEUE_WINDOW_SIZE) {
+        newQueueTracks = newQueueTracks.subList(0, QUEUE_WINDOW_SIZE)
     }
-    exo.addMediaItems(newMediaItems)
+
+    // Keep the longest matching prefix of already-buffered items and rebuild only from
+    // the first divergence. A pure append (the common window top-up) touches nothing
+    // ExoPlayer has already prepared, so gapless transitions survive.
+    val existingCount = exo.mediaItemCount - currentIndex - 1
+    var commonPrefix = 0
+    while (commonPrefix < existingCount && commonPrefix < newQueueTracks.size &&
+        extractTrackId(exo.getMediaItemAt(currentIndex + 1 + commonPrefix).mediaId) == newQueueTracks[commonPrefix].id
+    ) {
+        commonPrefix++
+    }
+
+    if (exo.mediaItemCount > currentIndex + 1 + commonPrefix) {
+        exo.removeMediaItems(currentIndex + 1 + commonPrefix, exo.mediaItemCount)
+    }
+    if (commonPrefix < newQueueTracks.size) {
+        exo.addMediaItems(
+            newQueueTracks.subList(commonPrefix, newQueueTracks.size).map { makeMediaItem(it, mediaIdFor(it)) },
+        )
+    }
 }
 
 /** Desired upcoming list after the current track: playNext + upNext + remaining originals, with the playing temp track ([currentId]) skipped. */
@@ -203,7 +232,8 @@ internal fun TrackPlayerCore.updatePlayerQueue(tracks: List<TrackItem>) {
         return
     }
 
-    val mediaItems = tracks.map { makeMediaItem(it, mediaIdFor(it)) }
+    currentTrackIndex = 0
+    val mediaItems = tracks.take(1 + QUEUE_WINDOW_SIZE).map { makeMediaItem(it, mediaIdFor(it)) }
     exo.setMediaItems(mediaItems, true)
     if (exo.playbackState == Player.STATE_IDLE && mediaItems.isNotEmpty()) {
         exo.prepare()

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -101,7 +101,7 @@ internal fun TrackPlayerCore.rebuildQueueFromCurrentPosition() {
     val currentTrackId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
 
     if (
-        currentTrackId != null && 
+        currentTrackId != null &&
         currentTracks.none { it.id == currentTrackId } &&
         currentTemporaryType == TrackPlayerCore.TemporaryType.NONE
     ) {
@@ -269,15 +269,17 @@ internal fun TrackPlayerCore.makeMediaItem(
         try {
             val headersRaw = payload.toHashMap()["headers"]
             if (headersRaw is Map<*, *>) {
-                val headers = headersRaw
-                    .mapNotNull { (k, v) -> if (k is String && v is String) k to v else null }
-                    .toMap()
+                val headers =
+                    headersRaw
+                        .mapNotNull { (k, v) -> if (k is String && v is String) k to v else null }
+                        .toMap()
                 if (headers.isNotEmpty()) {
                     com.margelo.nitro.nitroplayer.media.AuthAwareHttpDataSourceFactory
                         .setHeadersForUrl(effectiveUrl, headers)
                 }
             }
-        } catch (_: Exception) {}
+        } catch (_: Exception) {
+        }
     }
 
     return MediaItem

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerSetup.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerSetup.kt
@@ -47,8 +47,11 @@ internal fun TrackPlayerCore.initFromService(binder: NitroPlayerPlaybackService.
     }
 
     // Start progress ticks on the main looper
-    playerHandler.postDelayed(progressUpdateRunnable, 250)
+    playerHandler.postDelayed(progressUpdateRunnable, TrackPlayerCore.PROGRESS_INTERVAL_MS)
 
     // Signal that the player is ready — unblocks all withPlayerContext callers
     completeServiceReady()
+
+    // Flush any commands JS issued before the service bound, in their original order
+    startCommandDraining()
 }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerSetup.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerSetup.kt
@@ -43,7 +43,8 @@ internal fun TrackPlayerCore.initFromService(binder: NitroPlayerPlaybackService.
     if (sessionId != 0) {
         try {
             EqualizerCore.getInstance(context).initialize(sessionId)
-        } catch (_: Exception) { }
+        } catch (_: Exception) {
+        }
     }
 
     // Start progress ticks on the main looper

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerTempQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerTempQueue.kt
@@ -14,16 +14,21 @@ import com.margelo.nitro.nitroplayer.TrackItem
 suspend fun TrackPlayerCore.loadPlaylist(
     playlistId: String,
     startIndex: Int? = null,
-) =
-    withPlayerContext {
+) = withPlayerContext { loadPlaylistOnQueue(playlistId, startIndex) }
+
+internal fun TrackPlayerCore.loadPlaylistOnQueue(
+    playlistId: String,
+    startIndex: Int? = null,
+) {
+    run {
         playNextStack.clear()
         upNextQueue.clear()
         currentTemporaryType = TrackPlayerCore.TemporaryType.NONE
-        val playlist = playlistManager.getPlaylist(playlistId) ?: return@withPlayerContext
+        val playlist = playlistManager.getPlaylist(playlistId) ?: return@run
 
         val targetIndex =
             if (startIndex != null) {
-                if (startIndex < 0 || startIndex >= playlist.tracks.size) return@withPlayerContext
+                if (startIndex < 0 || startIndex >= playlist.tracks.size) return@run
                 startIndex
             } else {
                 0
@@ -41,6 +46,7 @@ suspend fun TrackPlayerCore.loadPlaylist(
         checkUpcomingTracksForUrls(lookaheadCount)
         notifyTemporaryQueueChange()
     }
+}
 
 /**
  * Debounced update — coalesces rapid back-to-back mutations into one player rebuild.
@@ -80,39 +86,43 @@ internal fun TrackPlayerCore.addToUpNextInternal(trackId: String) {
 
 // ── Remove / clear ────────────────────────────────────────────────────────
 
-suspend fun TrackPlayerCore.removeFromPlayNext(trackId: String): Boolean =
-    withPlayerContext {
-        val idx = playNextStack.indexOfFirst { it.id == trackId }
-        if (idx < 0) return@withPlayerContext false
-        playNextStack.removeAt(idx)
-        if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
-        notifyTemporaryQueueChange()
-        true
-    }
+suspend fun TrackPlayerCore.removeFromPlayNext(trackId: String): Boolean = withPlayerContext { removeFromPlayNextOnQueue(trackId) }
 
-suspend fun TrackPlayerCore.removeFromUpNext(trackId: String): Boolean =
-    withPlayerContext {
-        val idx = upNextQueue.indexOfFirst { it.id == trackId }
-        if (idx < 0) return@withPlayerContext false
-        upNextQueue.removeAt(idx)
-        if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
-        notifyTemporaryQueueChange()
-        true
-    }
+internal fun TrackPlayerCore.removeFromPlayNextOnQueue(trackId: String): Boolean {
+    val idx = playNextStack.indexOfFirst { it.id == trackId }
+    if (idx < 0) return false
+    playNextStack.removeAt(idx)
+    if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
+    notifyTemporaryQueueChange()
+    return true
+}
 
-suspend fun TrackPlayerCore.clearPlayNext() =
-    withPlayerContext {
-        playNextStack.clear()
-        if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
-        notifyTemporaryQueueChange()
-    }
+suspend fun TrackPlayerCore.removeFromUpNext(trackId: String): Boolean = withPlayerContext { removeFromUpNextOnQueue(trackId) }
 
-suspend fun TrackPlayerCore.clearUpNext() =
-    withPlayerContext {
-        upNextQueue.clear()
-        if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
-        notifyTemporaryQueueChange()
-    }
+internal fun TrackPlayerCore.removeFromUpNextOnQueue(trackId: String): Boolean {
+    val idx = upNextQueue.indexOfFirst { it.id == trackId }
+    if (idx < 0) return false
+    upNextQueue.removeAt(idx)
+    if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
+    notifyTemporaryQueueChange()
+    return true
+}
+
+suspend fun TrackPlayerCore.clearPlayNext() = withPlayerContext { clearPlayNextOnQueue() }
+
+internal fun TrackPlayerCore.clearPlayNextOnQueue() {
+    playNextStack.clear()
+    if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
+    notifyTemporaryQueueChange()
+}
+
+suspend fun TrackPlayerCore.clearUpNext() = withPlayerContext { clearUpNextOnQueue() }
+
+internal fun TrackPlayerCore.clearUpNextOnQueue() {
+    upNextQueue.clear()
+    if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
+    notifyTemporaryQueueChange()
+}
 
 // ── Reorder ───────────────────────────────────────────────────────────────
 
@@ -123,26 +133,30 @@ suspend fun TrackPlayerCore.clearUpNext() =
 suspend fun TrackPlayerCore.reorderTemporaryTrack(
     trackId: String,
     newIndex: Int,
-): Boolean =
-    withPlayerContext {
-        val combined = (playNextStack + upNextQueue).toMutableList()
-        val fromIdx = combined.indexOfFirst { it.id == trackId }
-        if (fromIdx < 0) return@withPlayerContext false
-        val track = combined.removeAt(fromIdx)
-        val clampedIndex = newIndex.coerceIn(0, combined.size)
-        combined.add(clampedIndex, track)
+): Boolean = withPlayerContext { reorderTemporaryTrackOnQueue(trackId, newIndex) }
 
-        // Split back at original playNextStack.size boundary (reduced if an item was moved out)
-        val pnSize = playNextStack.size
-        playNextStack.clear()
-        upNextQueue.clear()
-        playNextStack.addAll(combined.take(pnSize))
-        upNextQueue.addAll(combined.drop(pnSize))
+internal fun TrackPlayerCore.reorderTemporaryTrackOnQueue(
+    trackId: String,
+    newIndex: Int,
+): Boolean {
+    val combined = (playNextStack + upNextQueue).toMutableList()
+    val fromIdx = combined.indexOfFirst { it.id == trackId }
+    if (fromIdx < 0) return false
+    val track = combined.removeAt(fromIdx)
+    val clampedIndex = newIndex.coerceIn(0, combined.size)
+    combined.add(clampedIndex, track)
 
-        if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
-        notifyTemporaryQueueChange()
-        true
-    }
+    // Split back at original playNextStack.size boundary (reduced if an item was moved out)
+    val pnSize = playNextStack.size
+    playNextStack.clear()
+    upNextQueue.clear()
+    playNextStack.addAll(combined.take(pnSize))
+    upNextQueue.addAll(combined.drop(pnSize))
+
+    if (isExoInitialized && exo.currentMediaItem != null) rebuildQueueFromCurrentPosition()
+    notifyTemporaryQueueChange()
+    return true
+}
 
 // ── Read-only accessors ────────────────────────────────────────────────────
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerUrlLoader.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerUrlLoader.kt
@@ -12,8 +12,10 @@ import com.margelo.nitro.nitroplayer.TrackItem
 
 // ── Track updates (URL resolution) ────────────────────────────────────────
 
-suspend fun TrackPlayerCore.updateTracks(tracks: List<TrackItem>) =
-    withPlayerContext {
+suspend fun TrackPlayerCore.updateTracks(tracks: List<TrackItem>) = withPlayerContext { updateTracksOnQueue(tracks) }
+
+internal fun TrackPlayerCore.updateTracksOnQueue(tracks: List<TrackItem>) {
+    run {
         val currentTrack = getCurrentTrack()
         val currentTrackId = currentTrack?.id
         val currentTrackIsEmpty = currentTrack?.url.isNullOrEmpty()
@@ -32,7 +34,7 @@ suspend fun TrackPlayerCore.updateTracks(tracks: List<TrackItem>) =
                     else -> true
                 }
             }
-        if (safeTracks.isEmpty()) return@withPlayerContext
+        if (safeTracks.isEmpty()) return@run
 
         val affectedPlaylists: Map<String, Int> = playlistManager.updateTracks(safeTracks)
 
@@ -64,12 +66,13 @@ suspend fun TrackPlayerCore.updateTracks(tracks: List<TrackItem>) =
                 } else {
                     rebuildQueueFromCurrentPosition()
                 }
-                return@withPlayerContext
+                return@run
             }
 
             rebuildQueueFromCurrentPosition()
         }
     }
+}
 
 // ── Track queries ─────────────────────────────────────────────────────────
 
@@ -84,14 +87,42 @@ internal fun TrackPlayerCore.getTracksNeedingUrlsInternal(): List<TrackItem> {
 
 suspend fun TrackPlayerCore.getNextTracks(count: Int): List<TrackItem> = withPlayerContext { getNextTracksInternal(count) }
 
+/**
+ * Walks the queue structure directly instead of materializing the whole queue — this
+ * runs on every skip and every progress tick, so it must not be O(playlist) just to
+ * read the next few tracks.
+ */
 internal fun TrackPlayerCore.getNextTracksInternal(count: Int): List<TrackItem> {
-    val actualQueue = getActualQueueInternal()
-    if (actualQueue.isEmpty()) return emptyList()
-    val currentIdx = actualQueue.indexOfFirst { it.id == getCurrentTrack()?.id }
-    if (currentIdx == -1) return emptyList()
-    val start = currentIdx + 1
-    val end = minOf(start + count, actualQueue.size)
-    return if (start < actualQueue.size) actualQueue.subList(start, end) else emptyList()
+    if (count <= 0) return emptyList()
+    val out = ArrayList<TrackItem>(count)
+    val currentId = if (isExoInitialized) exo.currentMediaItem?.mediaId?.let { extractTrackId(it) } else null
+
+    var skippedPlayNext = currentTemporaryType != TrackPlayerCore.TemporaryType.PLAY_NEXT
+    for (track in playNextStack) {
+        if (!skippedPlayNext && track.id == currentId) {
+            skippedPlayNext = true
+            continue
+        }
+        out.add(track)
+        if (out.size == count) return out
+    }
+
+    var skippedUpNext = currentTemporaryType != TrackPlayerCore.TemporaryType.UP_NEXT
+    for (track in upNextQueue) {
+        if (!skippedUpNext && track.id == currentId) {
+            skippedUpNext = true
+            continue
+        }
+        out.add(track)
+        if (out.size == count) return out
+    }
+
+    var index = currentTrackIndex + 1
+    while (index < currentTracks.size && out.size < count) {
+        out.add(currentTracks[index])
+        index++
+    }
+    return out
 }
 
 suspend fun TrackPlayerCore.getCurrentTrackIndex(): Int = withPlayerContext { currentTrackIndex }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
@@ -39,6 +39,15 @@ class DownloadDatabase private constructor(
     }
 
     private val downloadedTracks = mutableMapOf<String, DownloadedTrackRecord>()
+
+    /**
+     * Memoized `File.exists()` verdicts, keyed by track ID.
+     *
+     * Queue building asks "is this downloaded?" once per track, and each answer used to
+     * cost a stat() — O(playlist) syscalls per rebuild, on the main looper. Records only
+     * change through this class, so the verdict is cached and dropped in [saveToDisk].
+     */
+    private val existenceCache = mutableMapOf<String, Boolean>()
     private val playlistTracks = mutableMapOf<String, MutableSet<String>>()
     private val fileManager = DownloadFileManager.getInstance(context)
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -82,9 +91,19 @@ class DownloadDatabase private constructor(
     fun isTrackDownloaded(trackId: String): Boolean {
         synchronized(this) {
             val record = downloadedTracks[trackId] ?: return false
-            // Verify file still exists
-            return File(record.localPath).exists()
+            return cachedFileExists(trackId, record.localPath)
         }
+    }
+
+    /** Caller must hold the monitor. */
+    private fun cachedFileExists(
+        trackId: String,
+        path: String,
+    ): Boolean = existenceCache.getOrPut(trackId) { File(path).exists() }
+
+    /** Drops every memoized verdict — files may have changed outside the app. */
+    fun invalidateExistenceCache() {
+        synchronized(this) { existenceCache.clear() }
     }
 
     fun isPlaylistDownloaded(playlistId: String): Boolean {
@@ -118,8 +137,8 @@ class DownloadDatabase private constructor(
         synchronized(this) {
             val record = downloadedTracks[trackId] ?: return null
 
-            // Verify file still exists
-            if (!File(record.localPath).exists()) {
+            // Verify file still exists (memoized)
+            if (!cachedFileExists(trackId, record.localPath)) {
                 // File was deleted externally, clean up record
                 downloadedTracks.remove(trackId)
                 saveToDisk()
@@ -302,6 +321,9 @@ class DownloadDatabase private constructor(
 
     // Persistence — called while holding synchronized(this); snapshots data then writes on IO.
     private fun saveToDisk() {
+        // Every record mutation funnels through here, so this is the one place that has
+        // to drop memoized File.exists() verdicts.
+        existenceCache.clear()
         val trackSnapshot = downloadedTracks.toMap()
         val playlistSnapshot = playlistTracks.mapValues { it.value.toSet() }
         ioScope.launch {

--- a/react-native-nitro-player/ios/HybridTrackPlayer.swift
+++ b/react-native-nitro-player/ios/HybridTrackPlayer.swift
@@ -25,40 +25,63 @@ final class HybridTrackPlayer: HybridTrackPlayerSpec {
     super.init()
   }
 
+  // MARK: - Ordered dispatch
+  //
+  // `Promise.async` starts an unordered Task, so the hop onto the player queue used
+  // to happen at an arbitrary later point: two calls made in order from JS could
+  // reach the player in reverse order (play-then-pause landing as pause-then-play).
+  // Enqueueing synchronously here — on the JS thread, at call time — makes the serial
+  // queue's FIFO order equal the JS call order.
+
+  private func enqueue<T>(_ block: @escaping () -> T) -> Promise<T> {
+    let promise = Promise<T>()
+    core.playerQueue.async { promise.resolve(withResult: block()) }
+    return promise
+  }
+
+  private func enqueueThrowing<T>(_ block: @escaping () throws -> T) -> Promise<T> {
+    let promise = Promise<T>()
+    core.playerQueue.async {
+      do { promise.resolve(withResult: try block()) }
+      catch { promise.reject(withError: error) }
+    }
+    return promise
+  }
+
   // MARK: - Playback Control (async Promise<Void>)
 
   func play() throws -> Promise<Void> {
-    Promise.async { await self.core.play() }
+    enqueue { self.core.playOnQueue() }
   }
 
   func pause() throws -> Promise<Void> {
-    Promise.async { await self.core.pause() }
+    enqueue { self.core.pauseOnQueue() }
   }
 
   func seek(position: Double) throws -> Promise<Void> {
-    Promise.async { await self.core.seek(position: position) }
+    enqueue { self.core.seekOnQueue(position: position) }
   }
 
   func skipToNext() throws -> Promise<Void> {
-    Promise.async { await self.core.skipToNext() }
+    enqueue { self.core.skipToNextOnQueue() }
   }
 
   func skipToPrevious() throws -> Promise<Void> {
-    Promise.async { await self.core.skipToPrevious() }
+    enqueue { self.core.skipToPreviousOnQueue() }
   }
 
   func playSong(songId: String, fromPlaylist: String?) throws -> Promise<Void> {
-    Promise.async { await self.core.playSong(songId: songId, fromPlaylist: fromPlaylist) }
+    enqueue { self.core.playSongInternal(songId: songId, fromPlaylist: fromPlaylist) }
   }
 
   func skipToIndex(index: Double) throws -> Promise<Bool> {
-    Promise.async { await self.core.skipToIndex(index: Int(index)) }
+    enqueue { self.core.skipToIndexOnQueue(index: Int(index)) }
   }
 
   // MARK: - Repeat / Volume / Config
 
   func setRepeatMode(mode: RepeatMode) throws -> Promise<Void> {
-    Promise.async { await self.core.setRepeatMode(mode: mode) }
+    enqueue { self.core.setRepeatModeOnQueue(mode: mode) }
   }
 
   func getRepeatMode() throws -> RepeatMode {
@@ -66,12 +89,12 @@ final class HybridTrackPlayer: HybridTrackPlayerSpec {
   }
 
   func setVolume(volume: Double) throws -> Promise<Void> {
-    Promise.async { await self.core.setVolume(volume: volume) }
+    enqueue { self.core.setVolumeOnQueue(volume: volume) }
   }
 
   func configure(config: PlayerConfig) throws -> Promise<Void> {
-    Promise.async {
-      await self.core.configure(
+    enqueue {
+      self.core.configureOnQueue(
         androidAutoEnabled: config.androidAutoEnabled,
         carPlayEnabled: config.carPlayEnabled,
         showInNotification: config.showInNotification,
@@ -83,80 +106,80 @@ final class HybridTrackPlayer: HybridTrackPlayerSpec {
   // MARK: - Queue / State reads
 
   func getActualQueue() throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getActualQueue() }
+    enqueue { self.core.getActualQueueInternal() }
   }
 
   func getState() throws -> Promise<PlayerState> {
-    Promise.async { await self.core.getState() }
+    enqueue { self.core.getStateInternal() }
   }
 
   func getCurrentTrackIndex() throws -> Promise<Double> {
-    Promise.async { Double(await self.core.getCurrentTrackIndex()) }
+    enqueue { Double(self.core.currentTrackIndex) }
   }
 
   // MARK: - URL updates / lazy loading
 
   func updateTracks(tracks: [TrackItem]) throws -> Promise<Void> {
-    Promise.async { await self.core.updateTracks(tracks: tracks) }
+    enqueue { self.core.updateTracksInternal(tracks: tracks) }
   }
 
   func getTracksById(trackIds: [String]) throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getTracksById(trackIds: trackIds) }
+    enqueue { self.core.getPlaylistManager().getTracksById(trackIds: trackIds) }
   }
 
   func getTracksNeedingUrls() throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getTracksNeedingUrls() }
+    enqueue { self.core.getTracksNeedingUrlsInternal() }
   }
 
   func getNextTracks(count: Double) throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getNextTracks(count: Int(count)) }
+    enqueue { self.core.getNextTracksInternal(count: Int(count)) }
   }
 
   // MARK: - Playback speed
   func setPlaybackSpeed(speed: Double) throws -> Promise<Void> {
-    Promise.async { await self.core.setPlaybackSpeed(speed) }
+    enqueue { self.core.setPlaybackSpeedOnQueue(speed) }
   }
 
   func getPlaybackSpeed() throws -> Promise<Double> {
-    Promise.async { await self.core.getPlaybackSpeed() }
+    enqueue { self.core.currentPlaybackSpeed }
   }
 
   // MARK: - Temporary queue v2
 
   func addToUpNext(trackId: String) throws -> Promise<Void> {
-    Promise.async { try await self.core.addToUpNext(trackId: trackId) }
+    enqueueThrowing { try self.core.addToUpNextOnQueue(trackId: trackId) }
   }
 
   func playNext(trackId: String) throws -> Promise<Void> {
-    Promise.async { try await self.core.playNext(trackId: trackId) }
+    enqueueThrowing { try self.core.playNextOnQueue(trackId: trackId) }
   }
 
   func removeFromPlayNext(trackId: String) throws -> Promise<Bool> {
-    Promise.async { await self.core.removeFromPlayNext(trackId: trackId) }
+    enqueue { self.core.removeFromPlayNextOnQueue(trackId: trackId) }
   }
 
   func removeFromUpNext(trackId: String) throws -> Promise<Bool> {
-    Promise.async { await self.core.removeFromUpNext(trackId: trackId) }
+    enqueue { self.core.removeFromUpNextOnQueue(trackId: trackId) }
   }
 
   func clearPlayNext() throws -> Promise<Void> {
-    Promise.async { await self.core.clearPlayNext() }
+    enqueue { self.core.clearPlayNextOnQueue() }
   }
 
   func clearUpNext() throws -> Promise<Void> {
-    Promise.async { await self.core.clearUpNext() }
+    enqueue { self.core.clearUpNextOnQueue() }
   }
 
   func reorderTemporaryTrack(trackId: String, newIndex: Double) throws -> Promise<Bool> {
-    Promise.async { await self.core.reorderTemporaryTrack(trackId: trackId, newIndex: Int(newIndex)) }
+    enqueue { self.core.reorderTemporaryTrackOnQueue(trackId: trackId, newIndex: Int(newIndex)) }
   }
 
   func getPlayNextQueue() throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getPlayNextQueue() }
+    enqueue { self.core.playNextStack }
   }
 
   func getUpNextQueue() throws -> Promise<[TrackItem]> {
-    Promise.async { await self.core.getUpNextQueue() }
+    enqueue { self.core.upNextQueue }
   }
 
   // MARK: - Android Auto (iOS no-op)

--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -246,7 +246,7 @@ class TrackPlayerCore: NSObject {
       NotificationCenter.default.removeObserver(self)
       self.pathMonitor?.cancel()
       self.pathMonitor = nil
-      self.preloadedAssets.values.forEach { $0.cancelLoading() }
+      for asset in self.preloadedAssets.values { asset.cancelLoading() }
       self.preloadedAssets.removeAll()
       self.failedItemRetryCounts.removeAll()
       self.redirectResolver.clear()

--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -26,6 +26,10 @@ class TrackPlayerCore: NSObject {
     static let preferredForwardBufferDuration: Double = 30.0
     static let preloadAssetKeys: [String] = ["playable", "duration", "tracks", "preferredTransform"]
     static let gaplessPreloadCount: Int = 3
+    /// Upcoming AVPlayerItems kept materialized behind the current one. The logical
+    /// queue (currentTracks + temp lists) stays complete; only the AVQueuePlayer is
+    /// windowed, and it is topped up on every item transition.
+    static let queueWindowSize: Int = 4
     // Stall & failure recovery
     static let maxFailedItemRetries: Int = 3
     static let failedItemRetryDelay: TimeInterval = 2.0
@@ -44,7 +48,10 @@ class TrackPlayerCore: NSObject {
   internal var currentPlaylistId: String?
   internal var currentTrackIndex: Int = -1
   internal var currentTracks: [TrackItem] = []
-  internal var pendingPlaylistUpdateWorkItem: DispatchWorkItem?
+  // Bumped on every updatePlaylist request (playerQueue-owned). A queued rebuild
+  // whose generation is stale was superseded by a later request and is dropped,
+  // so a burst of playlist mutations collapses into a single rebuild.
+  internal var playlistUpdateGeneration: UInt64 = 0
   internal var isManuallySeeked = false
   internal var currentRepeatMode: RepeatMode = .off
   internal var currentPlaybackSpeed: Double = 1.0
@@ -239,6 +246,7 @@ class TrackPlayerCore: NSObject {
       NotificationCenter.default.removeObserver(self)
       self.pathMonitor?.cancel()
       self.pathMonitor = nil
+      self.preloadedAssets.values.forEach { $0.cancelLoading() }
       self.preloadedAssets.removeAll()
       self.failedItemRetryCounts.removeAll()
       self.redirectResolver.clear()

--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -292,7 +292,8 @@ extension TrackPlayerCore {
         upNextQueue.removeAll()
         currentTemporaryType = .none
 
-        let allItems = currentTracks.compactMap { createGaplessPlayerItem(for: $0, isPreload: false) }
+        let windowed = currentTracks.prefix(1 + Constants.queueWindowSize)
+        let allItems = windowed.compactMap { createGaplessPlayerItem(for: $0, isPreload: false) }
         var lastItem: AVPlayerItem? = nil
         for item in allItems {
           player.insert(item, after: lastItem)
@@ -399,6 +400,15 @@ extension TrackPlayerCore {
       setupBoundaryTimeObserver()
     }
 
+    // Top up the windowed AVQueuePlayer — the item we just consumed freed a slot.
+    // Only when it is actually short: rebuildAVQueueFromCurrentPosition can fall into
+    // rebuildQueueFromPlaylistIndex (current track no longer in the playlist), which
+    // replaces the current item and re-enters this callback. The length check makes any
+    // such re-entry a no-op and terminate.
+    if player.items().count - 1 < Constants.queueWindowSize {
+      rebuildAVQueueFromCurrentPosition()
+    }
+
     // Preload upcoming tracks for gapless playback
     preloadUpcomingTracks(from: currentTrackIndex + 1)
     cleanupPreloadedAssets(keepingFrom: currentTrackIndex)
@@ -421,11 +431,12 @@ extension TrackPlayerCore {
           self?.player?.automaticallyWaitsToMinimizeStalling = false
           // Update now playing info now that duration is available (capture on playerQueue first)
           let state = self?.getStateInternal()
-          let queue = self?.getActualQueueInternal() ?? []
+          let metrics = self?.actualQueueMetrics() ?? (count: 0, position: -1)
           let track = self?.getCurrentTrack()
           DispatchQueue.main.async {
             if let track = track, let state = state {
-              self?.mediaSessionManager?.updateFromPlayerQueue(track: track, state: state, queue: queue)
+              self?.mediaSessionManager?.updateFromPlayerQueue(
+                track: track, state: state, queueCount: metrics.count, positionInQueue: metrics.position)
             }
           }
         } else if item.status == .failed {
@@ -438,9 +449,13 @@ extension TrackPlayerCore {
     currentItemObservers.append(statusObserver)
 
     let bufferEmptyObserver = item.observe(\.isPlaybackBufferEmpty, options: [.new]) { [weak self] item, _ in
-      if item.isPlaybackBufferEmpty {
+      guard item.isPlaybackBufferEmpty else { return }
+      // KVO fires on an arbitrary thread — emitStateChange reads playerQueue-owned
+      // state (currentTracks, temp queues, isRecoveringFromStall), so hop first.
+      self?.playerQueue.async {
+        guard let self, self.player?.currentItem === item else { return }
         NitroPlayerLogger.log("TrackPlayerCore", "⏸️ Buffer empty (buffering)")
-        self?.emitStateChange()
+        self.emitStateChange()
       }
     }
     currentItemObservers.append(bufferEmptyObserver)

--- a/react-native-nitro-player/ios/core/TrackPlayerNotify.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerNotify.swift
@@ -13,22 +13,24 @@ extension TrackPlayerCore {
   // Called on playerQueue — invoke listeners directly (Nitro handles JS thread hop)
   func notifyTrackChange(_ track: TrackItem, _ reason: Reason?) {
     onChangeTrackListeners.forEach { $0(track, reason) }
-    // Capture state + queue now (on playerQueue), pass pre-computed values to main
+    // Capture state + queue metrics now (on playerQueue), pass pre-computed values to main.
+    // Metrics, not the queue itself — the media session only needs count and position.
     let state = getStateInternal()
-    let queue = getActualQueueInternal()
+    let metrics = actualQueueMetrics()
     DispatchQueue.main.async { [weak self] in
-      self?.mediaSessionManager?.updateFromPlayerQueue(track: track, state: state, queue: queue)
+      self?.mediaSessionManager?.updateFromPlayerQueue(
+        track: track, state: state, queueCount: metrics.count, positionInQueue: metrics.position)
     }
   }
 
   func notifyPlaybackStateChange(_ state: TrackPlayerState, _ reason: Reason?) {
     onPlaybackStateChangeListeners.forEach { $0(state, reason) }
+    guard let track = getCurrentTrack() else { return }
     let playerState = getStateInternal()
-    let queue = getActualQueueInternal()
-    let track = getCurrentTrack()
+    let metrics = actualQueueMetrics()
     DispatchQueue.main.async { [weak self] in
-      guard let track = track else { return }
-      self?.mediaSessionManager?.updateFromPlayerQueue(track: track, state: playerState, queue: queue)
+      self?.mediaSessionManager?.updateFromPlayerQueue(
+        track: track, state: playerState, queueCount: metrics.count, positionInQueue: metrics.position)
     }
   }
 

--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -11,78 +11,88 @@ import MediaPlayer
 
 extension TrackPlayerCore {
 
-  func play() async {
+  // MARK: - Public commands
+  //
+  // Each command has a `…OnQueue` form that MUST run on `playerQueue` and an `async`
+  // shim for callers that are not already there (media-session remote commands).
+  // HybridTrackPlayer dispatches the `…OnQueue` form directly from the JS thread so
+  // the serial queue's FIFO order equals the JS call order — see HybridTrackPlayer.
+  //
+  // Reading `isCasting` inside the queue block (not before it) keeps every cast-vs-local
+  // decision on the thread that owns that flag.
+
+  func playOnQueue() {
     if isCasting {
       intendedToPlay = true
       castManager?.play()
       return
     }
-    await withPlayerQueueNoThrow { self.playInternal() }
+    playInternal()
   }
+  func play() async { await withPlayerQueueNoThrow { self.playOnQueue() } }
 
-  func pause() async {
+  func pauseOnQueue() {
     if isCasting {
       intendedToPlay = false
       castManager?.pause()
       return
     }
-    await withPlayerQueueNoThrow { self.pauseInternal() }
+    pauseInternal()
   }
+  func pause() async { await withPlayerQueueNoThrow { self.pauseOnQueue() } }
 
-  func seek(position: Double) async {
+  func seekOnQueue(position: Double) {
     if isCasting {
       castManager?.seek(to: position)
       return
     }
-    await withPlayerQueueNoThrow { self.seekInternal(position: position) }
+    seekInternal(position: position)
   }
+  func seek(position: Double) async { await withPlayerQueueNoThrow { self.seekOnQueue(position: position) } }
 
-  func skipToNext() async {
+  func skipToNextOnQueue() {
     if isCasting {
       castManager?.skipToNext()
       return
     }
-    await withPlayerQueueNoThrow { self.skipToNextInternal() }
+    skipToNextInternal()
   }
+  func skipToNext() async { await withPlayerQueueNoThrow { self.skipToNextOnQueue() } }
 
-  func skipToPrevious() async {
+  func skipToPreviousOnQueue() {
     if isCasting {
       // The receiver queue starts at the current track, so queuePreviousItem has nothing behind it — use core state instead.
-      await withPlayerQueueNoThrow { self.skipToPreviousCastInternal() }
+      skipToPreviousCastInternal()
       return
     }
-    await withPlayerQueueNoThrow { self.skipToPreviousInternal() }
+    skipToPreviousInternal()
   }
+  func skipToPrevious() async { await withPlayerQueueNoThrow { self.skipToPreviousOnQueue() } }
 
-  func setRepeatMode(mode: RepeatMode) async {
-    await withPlayerQueueNoThrow {
-      self.currentRepeatMode = mode
-      self.player?.actionAtItemEnd = (mode == .track) ? .none : .advance
-      if self.isCasting { self.castManager?.setQueueRepeatMode(mode) }
-      NitroPlayerLogger.log("TrackPlayerCore", "🔁 setRepeatMode: \(mode)")
-    }
+  func setRepeatModeOnQueue(mode: RepeatMode) {
+    currentRepeatMode = mode
+    player?.actionAtItemEnd = (mode == .track) ? .none : .advance
+    if isCasting { castManager?.setQueueRepeatMode(mode) }
+    NitroPlayerLogger.log("TrackPlayerCore", "🔁 setRepeatMode: \(mode)")
   }
+  func setRepeatMode(mode: RepeatMode) async { await withPlayerQueueNoThrow { self.setRepeatModeOnQueue(mode: mode) } }
 
-  func setVolume(volume: Double) async {
+  func setVolumeOnQueue(volume: Double) {
+    let clamped = max(0.0, min(100.0, volume))
     if isCasting {
-      let clamped = max(0.0, min(100.0, volume))
       castManager?.setVolume(Float(clamped / 100.0))
       return
     }
-    await withPlayerQueueNoThrow {
-      let clamped = max(0.0, min(100.0, volume))
-      let normalized = Float(clamped / 100.0)
-      self.player?.volume = normalized
-      NitroPlayerLogger.log("TrackPlayerCore", "🔊 Volume set to \(Int(clamped))% (normalized: \(normalized))")
-    }
+    let normalized = Float(clamped / 100.0)
+    player?.volume = normalized
+    NitroPlayerLogger.log("TrackPlayerCore", "🔊 Volume set to \(Int(clamped))% (normalized: \(normalized))")
   }
+  func setVolume(volume: Double) async { await withPlayerQueueNoThrow { self.setVolumeOnQueue(volume: volume) } }
 
-  func configure(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Int?) async {
-    await withPlayerQueueNoThrow {
-      if let la = lookaheadCount {
-        self.lookaheadCount = la
-        NitroPlayerLogger.log("TrackPlayerCore", "🔄 Lookahead count set to: \(la)")
-      }
+  func configureOnQueue(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Int?) {
+    if let la = lookaheadCount {
+      self.lookaheadCount = la
+      NitroPlayerLogger.log("TrackPlayerCore", "🔄 Lookahead count set to: \(la)")
     }
     DispatchQueue.main.async { [weak self] in
       self?.mediaSessionManager?.configure(
@@ -92,21 +102,26 @@ extension TrackPlayerCore {
       )
     }
   }
+  func configure(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Int?) async {
+    await withPlayerQueueNoThrow {
+      self.configureOnQueue(
+        androidAutoEnabled: androidAutoEnabled, carPlayEnabled: carPlayEnabled,
+        showInNotification: showInNotification, lookaheadCount: lookaheadCount)
+    }
+  }
 
-  func setPlaybackSpeed(_ speed: Double) async {
+  func setPlaybackSpeedOnQueue(_ speed: Double) {
+    currentPlaybackSpeed = speed
     if isCasting {
-      currentPlaybackSpeed = speed
       castManager?.setPlaybackRate(Float(speed))
       return
     }
-    await withPlayerQueueNoThrow {
-      self.currentPlaybackSpeed = speed
-      // Only update rate if currently playing; pause keeps rate at 0 until play() is called
-      if let player = self.player, player.rate != 0 {
-        player.rate = Float(speed)
-      }
+    // Only update rate if currently playing; pause keeps rate at 0 until play() is called
+    if let player = self.player, player.rate != 0 {
+      player.rate = Float(speed)
     }
   }
+  func setPlaybackSpeed(_ speed: Double) async { await withPlayerQueueNoThrow { self.setPlaybackSpeedOnQueue(speed) } }
 
   func getPlaybackSpeed() async -> Double {
     await withPlayerQueueNoThrow { self.currentPlaybackSpeed }
@@ -200,6 +215,12 @@ extension TrackPlayerCore {
           notifyTemporaryQueueChange()
         }
       }
+    }
+
+    // The AVQueuePlayer is windowed, so items().count is not the logical queue length.
+    // Top up first so there is always something to advance to while tracks remain.
+    if hasUpcomingTrack() {
+      if queuePlayer.items().count <= 1 { rebuildAVQueueFromCurrentPosition() }
     }
 
     if queuePlayer.items().count > 1 {

--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -48,7 +48,9 @@ extension TrackPlayerCore {
     }
     seekInternal(position: position)
   }
-  func seek(position: Double) async { await withPlayerQueueNoThrow { self.seekOnQueue(position: position) } }
+  func seek(position: Double) async {
+    await withPlayerQueueNoThrow { self.seekOnQueue(position: position) }
+  }
 
   func skipToNextOnQueue() {
     if isCasting {
@@ -75,7 +77,9 @@ extension TrackPlayerCore {
     if isCasting { castManager?.setQueueRepeatMode(mode) }
     NitroPlayerLogger.log("TrackPlayerCore", "🔁 setRepeatMode: \(mode)")
   }
-  func setRepeatMode(mode: RepeatMode) async { await withPlayerQueueNoThrow { self.setRepeatModeOnQueue(mode: mode) } }
+  func setRepeatMode(mode: RepeatMode) async {
+    await withPlayerQueueNoThrow { self.setRepeatModeOnQueue(mode: mode) }
+  }
 
   func setVolumeOnQueue(volume: Double) {
     let clamped = max(0.0, min(100.0, volume))
@@ -85,11 +89,17 @@ extension TrackPlayerCore {
     }
     let normalized = Float(clamped / 100.0)
     player?.volume = normalized
-    NitroPlayerLogger.log("TrackPlayerCore", "🔊 Volume set to \(Int(clamped))% (normalized: \(normalized))")
+    NitroPlayerLogger.log(
+      "TrackPlayerCore", "🔊 Volume set to \(Int(clamped))% (normalized: \(normalized))")
   }
-  func setVolume(volume: Double) async { await withPlayerQueueNoThrow { self.setVolumeOnQueue(volume: volume) } }
+  func setVolume(volume: Double) async {
+    await withPlayerQueueNoThrow { self.setVolumeOnQueue(volume: volume) }
+  }
 
-  func configureOnQueue(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Int?) {
+  func configureOnQueue(
+    androidAutoEnabled: Bool?, carPlayEnabled: Bool?,
+    showInNotification: Bool?, lookaheadCount: Int?
+  ) {
     if let la = lookaheadCount {
       self.lookaheadCount = la
       NitroPlayerLogger.log("TrackPlayerCore", "🔄 Lookahead count set to: \(la)")
@@ -102,7 +112,10 @@ extension TrackPlayerCore {
       )
     }
   }
-  func configure(androidAutoEnabled: Bool?, carPlayEnabled: Bool?, showInNotification: Bool?, lookaheadCount: Int?) async {
+  func configure(
+    androidAutoEnabled: Bool?, carPlayEnabled: Bool?,
+    showInNotification: Bool?, lookaheadCount: Int?
+  ) async {
     await withPlayerQueueNoThrow {
       self.configureOnQueue(
         androidAutoEnabled: androidAutoEnabled, carPlayEnabled: carPlayEnabled,
@@ -121,7 +134,9 @@ extension TrackPlayerCore {
       player.rate = Float(speed)
     }
   }
-  func setPlaybackSpeed(_ speed: Double) async { await withPlayerQueueNoThrow { self.setPlaybackSpeedOnQueue(speed) } }
+  func setPlaybackSpeed(_ speed: Double) async {
+    await withPlayerQueueNoThrow { self.setPlaybackSpeedOnQueue(speed) }
+  }
 
   func getPlaybackSpeed() async -> Double {
     await withPlayerQueueNoThrow { self.currentPlaybackSpeed }

--- a/react-native-nitro-player/ios/core/TrackPlayerQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueue.swift
@@ -150,16 +150,19 @@ extension TrackPlayerCore {
   /// arithmetically. `getActualQueueInternal()` copies every TrackItem to answer the
   /// same two questions — too expensive to run on every playback-state change.
   func actualQueueMetrics() -> (count: Int, position: Int) {
-    let before = currentTemporaryType != .none
-      ? min(currentTrackIndex + 1, currentTracks.count)
-      : max(0, currentTrackIndex)
+    let before: Int
+    if currentTemporaryType != .none {
+      before = min(currentTrackIndex + 1, currentTracks.count)
+    } else {
+      before = max(0, currentTrackIndex)
+    }
     let hasCurrent = getCurrentTrack() != nil
-    let playNextCount = currentTemporaryType == .playNext
-      ? max(0, playNextStack.count - 1) : playNextStack.count
-    let upNextCount = currentTemporaryType == .upNext
-      ? max(0, upNextQueue.count - 1) : upNextQueue.count
-    let after = currentTrackIndex + 1 < currentTracks.count
-      ? currentTracks.count - (currentTrackIndex + 1) : 0
+    let playNextCount =
+      currentTemporaryType == .playNext ? max(0, playNextStack.count - 1) : playNextStack.count
+    let upNextCount =
+      currentTemporaryType == .upNext ? max(0, upNextQueue.count - 1) : upNextQueue.count
+    let after =
+      currentTrackIndex + 1 < currentTracks.count ? currentTracks.count - (currentTrackIndex + 1) : 0
 
     let count = before + (hasCurrent ? 1 : 0) + playNextCount + upNextCount + after
     return (count, hasCurrent ? before : -1)

--- a/react-native-nitro-player/ios/core/TrackPlayerQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueue.swift
@@ -18,11 +18,13 @@ extension TrackPlayerCore {
     await withPlayerQueueNoThrow { self.getActualQueueInternal() }
   }
 
+  @discardableResult
+  func skipToIndexOnQueue(index: Int) -> Bool {
+    isCasting ? skipToIndexCastInternal(index: index) : skipToIndexInternal(index: index)
+  }
+
   func skipToIndex(index: Int) async -> Bool {
-    if isCasting {
-      return await withPlayerQueueNoThrow { self.skipToIndexCastInternal(index: index) }
-    }
-    return await withPlayerQueueNoThrow { self.skipToIndexInternal(index: index) }
+    await withPlayerQueueNoThrow { self.skipToIndexOnQueue(index: index) }
   }
 
   func playFromIndex(index: Int) async {
@@ -142,6 +144,25 @@ extension TrackPlayerCore {
       queue.append(contentsOf: currentTracks[(currentTrackIndex + 1)...])
     }
     return queue
+  }
+
+  /// Length of the logical queue and the current track's position in it, derived
+  /// arithmetically. `getActualQueueInternal()` copies every TrackItem to answer the
+  /// same two questions — too expensive to run on every playback-state change.
+  func actualQueueMetrics() -> (count: Int, position: Int) {
+    let before = currentTemporaryType != .none
+      ? min(currentTrackIndex + 1, currentTracks.count)
+      : max(0, currentTrackIndex)
+    let hasCurrent = getCurrentTrack() != nil
+    let playNextCount = currentTemporaryType == .playNext
+      ? max(0, playNextStack.count - 1) : playNextStack.count
+    let upNextCount = currentTemporaryType == .upNext
+      ? max(0, upNextQueue.count - 1) : upNextQueue.count
+    let after = currentTrackIndex + 1 < currentTracks.count
+      ? currentTracks.count - (currentTrackIndex + 1) : 0
+
+    let count = before + (hasCurrent ? 1 : 0) + playNextCount + upNextCount + after
+    return (count, hasCurrent ? before : -1)
   }
 
   func getCurrentTrack() -> TrackItem? {

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -11,6 +11,34 @@ import Foundation
 
 extension TrackPlayerCore {
 
+  /// Cancels an item's outstanding asset loading before it is released.
+  ///
+  /// `AVURLAsset.dealloc` blocks the deallocating thread inside `URLAssetFinalize`
+  /// until any in-flight `loadValuesAsynchronously` / resource-loader work finishes —
+  /// and AVPlayer tears removed items down on the MAIN thread. Dropping items without
+  /// cancelling first therefore stalls the main run loop (and with it RCTTiming, so
+  /// JS timers stop firing) for as long as the pending loads take.
+  /// `cancelLoading()` itself waits for in-flight work to unwind, so it is only worth
+  /// paying on a full teardown (playlist switch / jump), never on the incremental
+  /// window rebuild that runs on every playNext / addToUpNext.
+  ///
+  /// A cancelled asset must never be handed back out: `createGaplessPlayerItem` reuses
+  /// `preloadedAssets`, and reusing a cancelled one yields an item that fails and then
+  /// burns the failed-item retry budget. Evict it instead.
+  func cancelLoading(of item: AVPlayerItem) {
+    guard let asset = item.asset as? AVURLAsset else { return }
+    if let trackId = item.trackId, preloadedAssets[trackId] === asset {
+      preloadedAssets.removeValue(forKey: trackId)
+    }
+    asset.cancelLoading()
+  }
+
+  /// Removes every item from the player, cancelling their asset loads first.
+  func removeAllItemsCancellingLoads(_ player: AVQueuePlayer) {
+    for item in player.items() { cancelLoading(of: item) }
+    player.removeAllItems()
+  }
+
   func updatePlayerQueue(tracks: [TrackItem]) {
     // While casting, mirror the new queue to the Cast device instead of building
     // the local AVQueuePlayer (which would start local audio).
@@ -55,6 +83,7 @@ extension TrackPlayerCore {
     player?.automaticallyWaitsToMinimizeStalling = true
 
     // Clear old preloaded assets when loading new queue
+    preloadedAssets.values.forEach { $0.cancelLoading() }
     preloadedAssets.removeAll()
 
     guard let existingPlayer = self.player else {
@@ -63,7 +92,7 @@ extension TrackPlayerCore {
     }
 
     NitroPlayerLogger.log("TrackPlayerCore", "🔄 Removing \(existingPlayer.items().count) old items from player")
-    existingPlayer.removeAllItems()
+    removeAllItemsCancellingLoads(existingPlayer)
 
     // Lazy-load mode if the first track needs a URL. Tracks further in the queue with
     // empty URLs are dropped safely by compactMap below and resolved via onTracksNeedUpdate.
@@ -75,7 +104,9 @@ extension TrackPlayerCore {
       return
     }
 
-    let items = tracks.enumerated().compactMap { (index, track) -> AVPlayerItem? in
+    // Only materialize a window of items — the rest are added as playback advances.
+    let windowed = tracks.prefix(1 + Constants.queueWindowSize)
+    let items = windowed.enumerated().compactMap { (index, track) -> AVPlayerItem? in
       let isPreload = index < Constants.gaplessPreloadCount
       return createGaplessPlayerItem(for: track, isPreload: isPreload)
     }
@@ -182,7 +213,7 @@ extension TrackPlayerCore {
         player?.removeTimeObserver(boundaryObserver)
         self.boundaryTimeObserver = nil
       }
-      player?.removeAllItems()
+      if let p = player { removeAllItemsCancellingLoads(p) }
       self.currentTracks = fullPlaylist
       if let track = self.currentTracks[safe: index] {
         notifyTrackChange(track, .skip)
@@ -190,7 +221,8 @@ extension TrackPlayerCore {
       return true
     }
 
-    let tracksToPlay = Array(fullPlaylist[index...])
+    let windowEnd = min(index + 1 + Constants.queueWindowSize, fullPlaylist.count)
+    let tracksToPlay = Array(fullPlaylist[index..<windowEnd])
     NitroPlayerLogger.log("TrackPlayerCore", "   🔄 Creating gapless queue with \(tracksToPlay.count) tracks starting from index \(index)")
 
     let items = tracksToPlay.enumerated().compactMap { (offset, track) -> AVPlayerItem? in
@@ -212,7 +244,7 @@ extension TrackPlayerCore {
     // Re-enable stall waiting for the new first track
     player.automaticallyWaitsToMinimizeStalling = true
 
-    player.removeAllItems()
+    removeAllItemsCancellingLoads(player)
     var lastItem: AVPlayerItem? = nil
     for item in items {
       player.insert(item, after: lastItem)
@@ -308,6 +340,11 @@ extension TrackPlayerCore {
       newQueueTracks.append(contentsOf: currentTracks[(currentTrackIndex + 1)...])
     }
 
+    // Window the materialized queue — currentItemDidChange tops it up on every transition.
+    if newQueueTracks.count > Constants.queueWindowSize {
+      newQueueTracks.removeSubrange(Constants.queueWindowSize...)
+    }
+
     // Collect existing upcoming AVPlayerItems
     let upcomingItems: [AVPlayerItem]
     if let ci = currentItem, let ciIndex = playingItems.firstIndex(of: ci) {
@@ -370,19 +407,43 @@ extension TrackPlayerCore {
       return
     }
 
-    // Full rebuild path (no changedTrackIds — skip, reorder, etc.)
-    for item in playingItems where item != currentItem {
+    // Incremental path (no changedTrackIds — skip, reorder, window top-up).
+    // Keep the longest matching prefix of already-buffered items and only rebuild
+    // from the first divergence. A pure append (the common window top-up) therefore
+    // touches nothing that is already buffered, preserving gapless transitions.
+    var commonPrefix = 0
+    while commonPrefix < upcomingItems.count && commonPrefix < newQueueTracks.count
+      && upcomingItems[commonPrefix].trackId == newQueueTracks[commonPrefix].id {
+      commonPrefix += 1
+    }
+
+    for item in upcomingItems[commonPrefix...] {
       player.remove(item)
     }
 
-    var lastItem = currentItem
-    for (offset, track) in newQueueTracks.enumerated() {
+    var lastItem: AVPlayerItem? = commonPrefix > 0 ? upcomingItems[commonPrefix - 1] : currentItem
+    for offset in commonPrefix..<newQueueTracks.count {
       let isPreload = offset < Constants.gaplessPreloadCount
-      if let item = createGaplessPlayerItem(for: track, isPreload: isPreload) {
+      if let item = createGaplessPlayerItem(for: newQueueTracks[offset], isPreload: isPreload) {
         player.insert(item, after: lastItem)
         lastItem = item
       }
     }
+
+    NitroPlayerLogger.log("TrackPlayerCore",
+      "🔄 Incremental rebuild: kept \(commonPrefix) buffered items, created \(newQueueTracks.count - commonPrefix)")
+  }
+
+  /// True when the logical queue has a track after the current one, regardless of
+  /// how much of it is currently materialized into the AVQueuePlayer.
+  func hasUpcomingTrack() -> Bool {
+    let pendingPlayNext = currentTemporaryType == .playNext
+      ? max(0, playNextStack.count - 1) : playNextStack.count
+    if pendingPlayNext > 0 { return true }
+    let pendingUpNext = currentTemporaryType == .upNext
+      ? max(0, upNextQueue.count - 1) : upNextQueue.count
+    if pendingUpNext > 0 { return true }
+    return currentTrackIndex + 1 < currentTracks.count
   }
 
   /// Extracts custom HTTP headers (e.g. `Authorization`) from `extraPayload.headers`.
@@ -479,46 +540,40 @@ extension TrackPlayerCore {
     item.canUseNetworkResourcesForLiveStreamingWhilePaused = true
     item.trackId = track.id
 
-    if isPreload {
-      asset.loadValuesAsynchronously(forKeys: Constants.preloadAssetKeys) {
-        var allKeysLoaded = true
-        for key in Constants.preloadAssetKeys {
-          var error: NSError?
-          let status = asset.statusOfValue(forKey: key, error: &error)
-          if status == .failed {
-            NitroPlayerLogger.log("TrackPlayerCore", "⚠️ Failed to load key '\(key)' for \(track.title): \(error?.localizedDescription ?? "unknown")")
-            allKeysLoaded = false
-          }
-        }
-        if allKeysLoaded {
-          NitroPlayerLogger.log("TrackPlayerCore", "✅ All asset keys preloaded for \(track.title)")
-        }
-        // "tracks" key is now loaded — EQ tap attaches synchronously
-        EqualizerCore.shared.applyAudioMix(to: item)
-      }
-    } else {
-      EqualizerCore.shared.applyAudioMix(to: item)
-    }
+    // Deliberately NOT calling loadValuesAsynchronously here.
+    //
+    // AVURLAsset.dealloc blocks its thread inside URLAssetFinalize until any in-flight
+    // key load finishes — and AVPlayer tears removed items down on the MAIN thread, so
+    // an item discarded mid-load stalls the main run loop (and RCTTiming with it, which
+    // stops JS timers). Asset warm-up still happens in preloadUpcomingTracks, which only
+    // publishes assets into `preloadedAssets` once every key has finished loading, so a
+    // reused preloaded asset has nothing in flight either.
+    //
+    // Caveat: with the equalizer ENABLED, applyAudioMix still loads the "tracks" key
+    // asynchronously for assets that don't have it yet, so a small window remains. That
+    // is unchanged from before (it was already the non-preload path) and is strictly
+    // less in-flight work than the previous 4-key preload on every queued item.
+    EqualizerCore.shared.applyAudioMix(to: item)
 
     return item
   }
 
   /// Preloads assets for upcoming tracks to enable gapless playback
   func preloadUpcomingTracks(from startIndex: Int) {
-    // Capture the set of track IDs that already have AVPlayerItems in the queue.
+    // Snapshot every piece of playerQueue-owned state HERE (we are on playerQueue).
+    // `preloadQueue` must never touch currentTracks / preloadedAssets directly —
+    // Swift Array/Dictionary are not safe for concurrent access.
     let queuedTrackIds = Set(player?.items().compactMap { $0.trackId } ?? [])
+    let alreadyPreloaded = Set(preloadedAssets.keys)
+    let endIndex = min(startIndex + Constants.gaplessPreloadCount, currentTracks.count)
+    guard startIndex >= 0, startIndex < endIndex else { return }
+    let candidates = Array(currentTracks[startIndex..<endIndex])
 
     preloadQueue.async { [weak self] in
       guard let self else { return }
 
-      let tracks = self.currentTracks
-      let endIndex = min(startIndex + Constants.gaplessPreloadCount, tracks.count)
-
-      for i in startIndex..<endIndex {
-        guard i < tracks.count else { break }
-        let track = tracks[i]
-
-        if self.preloadedAssets[track.id] != nil || queuedTrackIds.contains(track.id) {
+      for track in candidates {
+        if alreadyPreloaded.contains(track.id) || queuedTrackIds.contains(track.id) {
           continue
         }
 
@@ -567,7 +622,8 @@ extension TrackPlayerCore {
 
     let assetsToRemove = self.preloadedAssets.keys.filter { !keepIds.contains($0) }
     for id in assetsToRemove {
-      self.preloadedAssets.removeValue(forKey: id)
+      // Cancel before dropping the last reference — see cancelLoading(of:).
+      self.preloadedAssets.removeValue(forKey: id)?.cancelLoading()
     }
 
     if !assetsToRemove.isEmpty {

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -83,7 +83,7 @@ extension TrackPlayerCore {
     player?.automaticallyWaitsToMinimizeStalling = true
 
     // Clear old preloaded assets when loading new queue
-    preloadedAssets.values.forEach { $0.cancelLoading() }
+    for asset in preloadedAssets.values { asset.cancelLoading() }
     preloadedAssets.removeAll()
 
     guard let existingPlayer = self.player else {
@@ -412,8 +412,10 @@ extension TrackPlayerCore {
     // from the first divergence. A pure append (the common window top-up) therefore
     // touches nothing that is already buffered, preserving gapless transitions.
     var commonPrefix = 0
-    while commonPrefix < upcomingItems.count && commonPrefix < newQueueTracks.count
-      && upcomingItems[commonPrefix].trackId == newQueueTracks[commonPrefix].id {
+    while commonPrefix < upcomingItems.count,
+      commonPrefix < newQueueTracks.count,
+      upcomingItems[commonPrefix].trackId == newQueueTracks[commonPrefix].id
+    {
       commonPrefix += 1
     }
 
@@ -430,18 +432,20 @@ extension TrackPlayerCore {
       }
     }
 
-    NitroPlayerLogger.log("TrackPlayerCore",
-      "🔄 Incremental rebuild: kept \(commonPrefix) buffered items, created \(newQueueTracks.count - commonPrefix)")
+    let created = newQueueTracks.count - commonPrefix
+    NitroPlayerLogger.log(
+      "TrackPlayerCore",
+      "🔄 Incremental rebuild: kept \(commonPrefix) buffered items, created \(created)")
   }
 
   /// True when the logical queue has a track after the current one, regardless of
   /// how much of it is currently materialized into the AVQueuePlayer.
   func hasUpcomingTrack() -> Bool {
-    let pendingPlayNext = currentTemporaryType == .playNext
-      ? max(0, playNextStack.count - 1) : playNextStack.count
+    let pendingPlayNext =
+      currentTemporaryType == .playNext ? max(0, playNextStack.count - 1) : playNextStack.count
     if pendingPlayNext > 0 { return true }
-    let pendingUpNext = currentTemporaryType == .upNext
-      ? max(0, upNextQueue.count - 1) : upNextQueue.count
+    let pendingUpNext =
+      currentTemporaryType == .upNext ? max(0, upNextQueue.count - 1) : upNextQueue.count
     if pendingUpNext > 0 { return true }
     return currentTrackIndex + 1 < currentTracks.count
   }

--- a/react-native-nitro-player/ios/core/TrackPlayerRecovery.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerRecovery.swift
@@ -64,7 +64,7 @@ extension TrackPlayerCore {
     notifyTracksNeedUpdate(tracks: [track], lookahead: lookaheadCount)
 
     // A preloaded asset for this track shares the same dead connection state.
-    preloadedAssets.removeValue(forKey: trackId)
+    preloadedAssets.removeValue(forKey: trackId)?.cancelLoading()
     // Surface a buffering state while the retry is pending.
     isRecoveringFromStall = true
     emitStateChange()

--- a/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
@@ -13,53 +13,53 @@ extension TrackPlayerCore {
   }
 
   func loadPlaylistOnQueue(playlistId: String, startIndex: Int? = nil) {
-      self.playNextStack.removeAll()
-      self.upNextQueue.removeAll()
-      self.currentTemporaryType = .none
+    self.playNextStack.removeAll()
+    self.upNextQueue.removeAll()
+    self.currentTemporaryType = .none
 
-      NitroPlayerLogger.log("TrackPlayerCore", "\n" + String(repeating: "🎼", count: Constants.playlistSeparatorLength))
-      NitroPlayerLogger.log("TrackPlayerCore", "📂 LOAD PLAYLIST REQUEST")
-      NitroPlayerLogger.log("TrackPlayerCore", "   Playlist ID: \(playlistId)")
-      NitroPlayerLogger.log("TrackPlayerCore", "   🧹 Cleared temporary tracks")
+    NitroPlayerLogger.log("TrackPlayerCore", "\n" + String(repeating: "🎼", count: Constants.playlistSeparatorLength))
+    NitroPlayerLogger.log("TrackPlayerCore", "📂 LOAD PLAYLIST REQUEST")
+    NitroPlayerLogger.log("TrackPlayerCore", "   Playlist ID: \(playlistId)")
+    NitroPlayerLogger.log("TrackPlayerCore", "   🧹 Cleared temporary tracks")
 
-      guard let playlist = self.playlistManager.getPlaylist(playlistId: playlistId) else {
-        NitroPlayerLogger.log("TrackPlayerCore", "   ❌ Playlist NOT FOUND")
-        NitroPlayerLogger.log("TrackPlayerCore", String(repeating: "🎼", count: Constants.playlistSeparatorLength) + "\n")
+    guard let playlist = self.playlistManager.getPlaylist(playlistId: playlistId) else {
+      NitroPlayerLogger.log("TrackPlayerCore", "   ❌ Playlist NOT FOUND")
+      NitroPlayerLogger.log("TrackPlayerCore", String(repeating: "🎼", count: Constants.playlistSeparatorLength) + "\n")
+      return
+    }
+
+    NitroPlayerLogger.log("TrackPlayerCore", "   ✅ Found playlist: \(playlist.name)")
+    NitroPlayerLogger.log("TrackPlayerCore", "   📋 Contains \(playlist.tracks.count) tracks:")
+    for (index, track) in playlist.tracks.enumerated() {
+      NitroPlayerLogger.log("TrackPlayerCore", "      [\(index + 1)] \(track.title) - \(track.artist)")
+    }
+    NitroPlayerLogger.log("TrackPlayerCore", String(repeating: "🎼", count: Constants.playlistSeparatorLength) + "\n")
+
+    let targetIndex: Int
+    if let startIndex {
+      guard startIndex >= 0 && startIndex < playlist.tracks.count else {
+        NitroPlayerLogger.log("TrackPlayerCore", "   ❌ Invalid start index: \(startIndex) (track count: \(playlist.tracks.count))")
         return
       }
+      targetIndex = startIndex
+    } else {
+      targetIndex = 0
+    }
 
-      NitroPlayerLogger.log("TrackPlayerCore", "   ✅ Found playlist: \(playlist.name)")
-      NitroPlayerLogger.log("TrackPlayerCore", "   📋 Contains \(playlist.tracks.count) tracks:")
-      for (index, track) in playlist.tracks.enumerated() {
-        NitroPlayerLogger.log("TrackPlayerCore", "      [\(index + 1)] \(track.title) - \(track.artist)")
-      }
-      NitroPlayerLogger.log("TrackPlayerCore", String(repeating: "🎼", count: Constants.playlistSeparatorLength) + "\n")
-
-      let targetIndex: Int
-      if let startIndex {
-        guard startIndex >= 0 && startIndex < playlist.tracks.count else {
-          NitroPlayerLogger.log("TrackPlayerCore", "   ❌ Invalid start index: \(startIndex) (track count: \(playlist.tracks.count))")
-          return
-        }
-        targetIndex = startIndex
-      } else {
-        targetIndex = 0
-      }
-
-      self.currentPlaylistId = playlistId
-      if targetIndex == 0 {
-        self.updatePlayerQueue(tracks: playlist.tracks)
-      } else {
-        // Bypass updatePlayerQueue to avoid emitting a spurious onTrackChange for index 0.
-        // Set currentTracks directly so rebuildQueueFromPlaylistIndex can use them.
-        self.currentTracks = playlist.tracks
-        self.preloadedAssets.values.forEach { $0.cancelLoading() }
-        self.preloadedAssets.removeAll()
-        _ = self.rebuildQueueFromPlaylistIndex(index: targetIndex)
-      }
-      self.emitStateChange()
-      self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
-      self.notifyTemporaryQueueChange()
+    self.currentPlaylistId = playlistId
+    if targetIndex == 0 {
+      self.updatePlayerQueue(tracks: playlist.tracks)
+    } else {
+      // Bypass updatePlayerQueue to avoid emitting a spurious onTrackChange for index 0.
+      // Set currentTracks directly so rebuildQueueFromPlaylistIndex can use them.
+      self.currentTracks = playlist.tracks
+      for asset in self.preloadedAssets.values { asset.cancelLoading() }
+      self.preloadedAssets.removeAll()
+      _ = self.rebuildQueueFromPlaylistIndex(index: targetIndex)
+    }
+    self.emitStateChange()
+    self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
+    self.notifyTemporaryQueueChange()
   }
 
   /// Callable from any thread (PlaylistManager runs on its own queue) — all state

--- a/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
@@ -9,7 +9,10 @@ import Foundation
 extension TrackPlayerCore {
 
   func loadPlaylist(playlistId: String, startIndex: Int? = nil) async {
-    await withPlayerQueueNoThrow {
+    await withPlayerQueueNoThrow { self.loadPlaylistOnQueue(playlistId: playlistId, startIndex: startIndex) }
+  }
+
+  func loadPlaylistOnQueue(playlistId: String, startIndex: Int? = nil) {
       self.playNextStack.removeAll()
       self.upNextQueue.removeAll()
       self.currentTemporaryType = .none
@@ -50,118 +53,122 @@ extension TrackPlayerCore {
         // Bypass updatePlayerQueue to avoid emitting a spurious onTrackChange for index 0.
         // Set currentTracks directly so rebuildQueueFromPlaylistIndex can use them.
         self.currentTracks = playlist.tracks
+        self.preloadedAssets.values.forEach { $0.cancelLoading() }
         self.preloadedAssets.removeAll()
         _ = self.rebuildQueueFromPlaylistIndex(index: targetIndex)
       }
       self.emitStateChange()
       self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
       self.notifyTemporaryQueueChange()
-    }
   }
 
+  /// Callable from any thread (PlaylistManager runs on its own queue) — all state
+  /// access happens on playerQueue.
   func updatePlaylist(playlistId: String) {
-    guard currentPlaylistId == playlistId else { return }
+    playerQueue.async { [weak self] in
+      guard let self, self.currentPlaylistId == playlistId else { return }
 
-    // Cancel any pending rebuild so back-to-back calls collapse into a single rebuild.
-    pendingPlaylistUpdateWorkItem?.cancel()
+      self.playlistUpdateGeneration &+= 1
+      let generation = self.playlistUpdateGeneration
 
-    let workItem = DispatchWorkItem { [weak self] in
-      guard let self, self.currentPlaylistId == playlistId,
-        let playlist = self.playlistManager.getPlaylist(playlistId: playlistId) else { return }
+      // Run at the tail of the current burst; stale generations drop out.
+      self.playerQueue.async { [weak self] in
+        guard let self, generation == self.playlistUpdateGeneration,
+          self.currentPlaylistId == playlistId,
+          let playlist = self.playlistManager.getPlaylist(playlistId: playlistId) else { return }
 
-      // If nothing is playing yet, do a full load
-      guard self.player?.currentItem != nil else {
-        self.updatePlayerQueue(tracks: playlist.tracks)
+        // If nothing is playing yet, do a full load
+        guard self.player?.currentItem != nil else {
+          self.updatePlayerQueue(tracks: playlist.tracks)
+          self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
+          return
+        }
+
+        // Update tracks list without interrupting playback
+        self.currentTracks = playlist.tracks
+        self.rebuildAVQueueFromCurrentPosition()
         self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
-        return
       }
-
-      // Update tracks list without interrupting playback
-      self.currentTracks = playlist.tracks
-      self.rebuildAVQueueFromCurrentPosition()
-      self.checkUpcomingTracksForUrls(lookahead: self.lookaheadCount)
     }
-
-    pendingPlaylistUpdateWorkItem = workItem
-    playerQueue.async(execute: workItem)
   }
 
+  func playNextOnQueue(trackId: String) throws {
+    guard let track = findTrackById(trackId) else {
+      throw NSError(domain: "NitroPlayer", code: 404, userInfo: [NSLocalizedDescriptionKey: "Track \(trackId) not found"])
+    }
+    NitroPlayerLogger.log("TrackPlayerCore", "⏭️ playNext(\(trackId))")
+    playNextStack.insert(track, at: 0)
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
+  }
   func playNext(trackId: String) async throws {
-    try await withPlayerQueue {
-      guard let track = self.findTrackById(trackId) else {
-        throw NSError(domain: "NitroPlayer", code: 404, userInfo: [NSLocalizedDescriptionKey: "Track \(trackId) not found"])
-      }
-      NitroPlayerLogger.log("TrackPlayerCore", "⏭️ playNext(\(trackId))")
-      self.playNextStack.insert(track, at: 0)
-      NitroPlayerLogger.log("TrackPlayerCore", "   ✅ Added '\(track.title)' to playNext stack (position: 1)")
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-    }
+    try await withPlayerQueue { try self.playNextOnQueue(trackId: trackId) }
   }
 
+  func addToUpNextOnQueue(trackId: String) throws {
+    guard let track = findTrackById(trackId) else {
+      throw NSError(domain: "NitroPlayer", code: 404, userInfo: [NSLocalizedDescriptionKey: "Track \(trackId) not found"])
+    }
+    NitroPlayerLogger.log("TrackPlayerCore", "📋 addToUpNext(\(trackId))")
+    upNextQueue.append(track)
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
+  }
   func addToUpNext(trackId: String) async throws {
-    try await withPlayerQueue {
-      guard let track = self.findTrackById(trackId) else {
-        throw NSError(domain: "NitroPlayer", code: 404, userInfo: [NSLocalizedDescriptionKey: "Track \(trackId) not found"])
-      }
-      NitroPlayerLogger.log("TrackPlayerCore", "📋 addToUpNext(\(trackId))")
-      self.upNextQueue.append(track)
-      NitroPlayerLogger.log("TrackPlayerCore", "   ✅ Added '\(track.title)' to upNext queue (position: \(self.upNextQueue.count))")
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-    }
+    try await withPlayerQueue { try self.addToUpNextOnQueue(trackId: trackId) }
   }
 
+  func removeFromPlayNextOnQueue(trackId: String) -> Bool {
+    guard let idx = playNextStack.firstIndex(where: { $0.id == trackId }) else { return false }
+    playNextStack.remove(at: idx)
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
+    return true
+  }
   func removeFromPlayNext(trackId: String) async -> Bool {
-    await withPlayerQueueNoThrow {
-      guard let idx = self.playNextStack.firstIndex(where: { $0.id == trackId }) else { return false }
-      self.playNextStack.remove(at: idx)
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-      return true
-    }
+    await withPlayerQueueNoThrow { self.removeFromPlayNextOnQueue(trackId: trackId) }
   }
 
+  func removeFromUpNextOnQueue(trackId: String) -> Bool {
+    guard let idx = upNextQueue.firstIndex(where: { $0.id == trackId }) else { return false }
+    upNextQueue.remove(at: idx)
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
+    return true
+  }
   func removeFromUpNext(trackId: String) async -> Bool {
-    await withPlayerQueueNoThrow {
-      guard let idx = self.upNextQueue.firstIndex(where: { $0.id == trackId }) else { return false }
-      self.upNextQueue.remove(at: idx)
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-      return true
-    }
+    await withPlayerQueueNoThrow { self.removeFromUpNextOnQueue(trackId: trackId) }
   }
 
-  func clearPlayNext() async {
-    await withPlayerQueueNoThrow {
-      self.playNextStack.removeAll()
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-    }
+  func clearPlayNextOnQueue() {
+    playNextStack.removeAll()
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
   }
+  func clearPlayNext() async { await withPlayerQueueNoThrow { self.clearPlayNextOnQueue() } }
 
-  func clearUpNext() async {
-    await withPlayerQueueNoThrow {
-      self.upNextQueue.removeAll()
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-    }
+  func clearUpNextOnQueue() {
+    upNextQueue.removeAll()
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
   }
+  func clearUpNext() async { await withPlayerQueueNoThrow { self.clearUpNextOnQueue() } }
 
+  func reorderTemporaryTrackOnQueue(trackId: String, newIndex: Int) -> Bool {
+    var combined = playNextStack + upNextQueue
+    guard let fromIdx = combined.firstIndex(where: { $0.id == trackId }) else { return false }
+    let track = combined.remove(at: fromIdx)
+    let clamped = newIndex.clamped(to: 0...combined.count)
+    combined.insert(track, at: clamped)
+    let pnSize = playNextStack.count
+    playNextStack = Array(combined.prefix(pnSize))
+    upNextQueue = Array(combined.dropFirst(pnSize))
+    if player?.currentItem != nil { rebuildAVQueueFromCurrentPosition() }
+    notifyTemporaryQueueChange()
+    return true
+  }
   func reorderTemporaryTrack(trackId: String, newIndex: Int) async -> Bool {
-    await withPlayerQueueNoThrow {
-      var combined = self.playNextStack + self.upNextQueue
-      guard let fromIdx = combined.firstIndex(where: { $0.id == trackId }) else { return false }
-      let track = combined.remove(at: fromIdx)
-      let clamped = newIndex.clamped(to: 0...combined.count)
-      combined.insert(track, at: clamped)
-      let pnSize = self.playNextStack.count
-      self.playNextStack = Array(combined.prefix(pnSize))
-      self.upNextQueue = Array(combined.dropFirst(pnSize))
-      if self.player?.currentItem != nil { self.rebuildAVQueueFromCurrentPosition() }
-      self.notifyTemporaryQueueChange()
-      return true
-    }
+    await withPlayerQueueNoThrow { self.reorderTemporaryTrackOnQueue(trackId: trackId, newIndex: newIndex) }
   }
 
   func getPlayNextQueue() async -> [TrackItem] {

--- a/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
@@ -175,14 +175,20 @@ extension TrackPlayerCore {
 
     var skippedPlayNext = currentTemporaryType != .playNext
     for track in playNextStack {
-      if !skippedPlayNext && track.id == currentId { skippedPlayNext = true; continue }
+      if !skippedPlayNext && track.id == currentId {
+        skippedPlayNext = true
+        continue
+      }
       out.append(track)
       if out.count == count { return out }
     }
 
     var skippedUpNext = currentTemporaryType != .upNext
     for track in upNextQueue {
-      if !skippedUpNext && track.id == currentId { skippedUpNext = true; continue }
+      if !skippedUpNext && track.id == currentId {
+        skippedUpNext = true
+        continue
+      }
       out.append(track)
       if out.count == count { return out }
     }

--- a/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
@@ -71,7 +71,7 @@ extension TrackPlayerCore {
     for trackId in updatedTrackIds {
       if self.preloadedAssets[trackId] != nil {
         NitroPlayerLogger.log("TrackPlayerCore", "🗑️ Invalidating preloaded asset for track: \(trackId)")
-        self.preloadedAssets.removeValue(forKey: trackId)
+        self.preloadedAssets.removeValue(forKey: trackId)?.cancelLoading()
       }
     }
 
@@ -129,7 +129,7 @@ extension TrackPlayerCore {
         // No AVPlayerItem exists yet — lazy-load mode: URLs were empty when the queue first loaded.
         NitroPlayerLogger.log("TrackPlayerCore",
           "🔄 No current item — full queue rebuild from currentTrackIndex \(self.currentTrackIndex)")
-        player.removeAllItems()
+        self.removeAllItemsCancellingLoads(player)
         var lastItem: AVPlayerItem? = nil
         for (offset, track) in self.currentTracks[max(0, self.currentTrackIndex)...].enumerated() {
           let isPreload = offset < Constants.gaplessPreloadCount
@@ -164,17 +164,35 @@ extension TrackPlayerCore {
     }
   }
 
+  /// Walks the queue structure directly instead of materializing the whole queue —
+  /// this runs on every skip and on the periodic boundary observer, so it must not
+  /// be O(playlist) just to read the next few tracks.
   func getNextTracksInternal(count: Int) -> [TrackItem] {
-    let actualQueue = getActualQueueInternal()
-    guard !actualQueue.isEmpty else { return [] }
+    guard count > 0 else { return [] }
+    var out: [TrackItem] = []
+    out.reserveCapacity(count)
+    let currentId = activeCurrentTrackId
 
-    guard let currentTrack = getCurrentTrack(),
-      let currentIndex = actualQueue.firstIndex(where: { $0.id == currentTrack.id })
-    else { return [] }
+    var skippedPlayNext = currentTemporaryType != .playNext
+    for track in playNextStack {
+      if !skippedPlayNext && track.id == currentId { skippedPlayNext = true; continue }
+      out.append(track)
+      if out.count == count { return out }
+    }
 
-    let startIndex = currentIndex + 1
-    let endIndex = min(startIndex + count, actualQueue.count)
-    return startIndex < actualQueue.count ? Array(actualQueue[startIndex..<endIndex]) : []
+    var skippedUpNext = currentTemporaryType != .upNext
+    for track in upNextQueue {
+      if !skippedUpNext && track.id == currentId { skippedUpNext = true; continue }
+      out.append(track)
+      if out.count == count { return out }
+    }
+
+    var index = currentTrackIndex + 1
+    while index < currentTracks.count && out.count < count {
+      out.append(currentTracks[index])
+      index += 1
+    }
+    return out
   }
 
   func checkUpcomingTracksForUrls(lookahead: Int = 5) {

--- a/react-native-nitro-player/ios/download/DownloadDatabase.swift
+++ b/react-native-nitro-player/ios/download/DownloadDatabase.swift
@@ -28,6 +28,39 @@ final class DownloadDatabase {
   private let queue = DispatchQueue(
     label: "com.nitroplayer.downloadDatabase", attributes: .concurrent)
 
+  /// Memoized `fileExists` verdicts, keyed by track ID.
+  ///
+  /// Queue building calls `isTrackDownloaded` / `getDownloadedTrack` once per track,
+  /// and each call used to stat() the file — O(playlist) syscalls per rebuild, on the
+  /// thread that also drives playback. Downloads only change through this class (or
+  /// through the user deleting files behind our back, which `syncDownloads()` handles),
+  /// so the verdict is cached and invalidated on every mutation.
+  /// Guarded by its own lock rather than `queue` so it can be filled from inside
+  /// concurrent read blocks (`queue.sync`) without a barrier.
+  private var existenceCache: [String: Bool] = [:]
+  private let existenceCacheLock = NSLock()
+
+  private func cachedFileExists(trackId: String, path: @autoclosure () -> String) -> Bool {
+    existenceCacheLock.lock()
+    let cached = existenceCache[trackId]
+    existenceCacheLock.unlock()
+    if let cached { return cached }
+
+    let exists = FileManager.default.fileExists(atPath: path())
+    existenceCacheLock.lock()
+    existenceCache[trackId] = exists
+    existenceCacheLock.unlock()
+    return exists
+  }
+
+  /// Drops every memoized verdict. Called on any record mutation, and safe to call
+  /// externally when files may have changed outside the app.
+  func invalidateExistenceCache() {
+    existenceCacheLock.lock()
+    existenceCache.removeAll()
+    existenceCacheLock.unlock()
+  }
+
   // MARK: - Initialization
 
   private init() {
@@ -70,22 +103,14 @@ final class DownloadDatabase {
         NitroPlayerLogger.log("DownloadDatabase", "🔍 Track \(trackId) NOT found in database")
         return false
       }
-      // Verify file still exists
-      let absolutePath = resolveAbsolutePath(for: record)
-      let exists = FileManager.default.fileExists(atPath: absolutePath)
-      if exists {
-        NitroPlayerLogger.log("DownloadDatabase", "✅ Track \(trackId) IS downloaded at \(absolutePath)")
-      } else {
-        NitroPlayerLogger.log("DownloadDatabase", "❌ Track \(trackId) record exists but file NOT found at \(absolutePath)")
-      }
-      return exists
+      // Verify file still exists (memoized — this runs once per track per queue rebuild)
+      return cachedFileExists(trackId: trackId, path: resolveAbsolutePath(for: record))
     }
   }
 
   private func _isTrackDownloadedUnsafe(trackId: String) -> Bool {
     guard let record = downloadedTracks[trackId] else { return false }
-    let absolutePath = resolveAbsolutePath(for: record)
-    return FileManager.default.fileExists(atPath: absolutePath)
+    return cachedFileExists(trackId: trackId, path: resolveAbsolutePath(for: record))
   }
 
   func isPlaylistDownloaded(playlistId: String) -> Bool {
@@ -137,8 +162,8 @@ final class DownloadDatabase {
       let absolutePath = resolveAbsolutePath(for: record)
       NitroPlayerLogger.log("DownloadDatabase", "   Found record, checking file at: \(absolutePath)")
 
-      // Verify file still exists
-      guard FileManager.default.fileExists(atPath: absolutePath) else {
+      // Verify file still exists (memoized)
+      guard cachedFileExists(trackId: trackId, path: absolutePath) else {
         NitroPlayerLogger.log("DownloadDatabase", "   ❌ File does NOT exist, cleaning up record")
         // File was deleted externally, clean up record
         queue.async(flags: .barrier) {
@@ -357,6 +382,9 @@ final class DownloadDatabase {
   // MARK: - Persistence
 
   private func saveToDisk() {
+    // Every record mutation funnels through here, so this is the one place that has
+    // to drop memoized fileExists verdicts.
+    invalidateExistenceCache()
     do {
       let tracksData = try JSONEncoder().encode(downloadedTracks)
       // Convert Set to Array for encoding

--- a/react-native-nitro-player/ios/media/MediaSessionManager.swift
+++ b/react-native-nitro-player/ios/media/MediaSessionManager.swift
@@ -60,7 +60,9 @@ class MediaSessionManager {
   //
   // Receives pre-computed values captured on playerQueue — no player access here.
 
-  func updateFromPlayerQueue(track: TrackItem, state: PlayerState, queueCount: Int, positionInQueue: Int) {
+  func updateFromPlayerQueue(
+    track: TrackItem, state: PlayerState, queueCount: Int, positionInQueue: Int
+  ) {
     cachedTrack = track
     cachedState = state
     cachedQueueCount = queueCount
@@ -94,7 +96,8 @@ class MediaSessionManager {
     }
 
     updateNowPlayingInfoInternal(
-      track: track, state: state, queueCount: cachedQueueCount, positionInQueue: cachedPositionInQueue)
+      track: track, state: state,
+      queueCount: cachedQueueCount, positionInQueue: cachedPositionInQueue)
     updateCommandCenterState(
       state: state, queueCount: cachedQueueCount, positionInQueue: cachedPositionInQueue)
   }

--- a/react-native-nitro-player/ios/media/MediaSessionManager.swift
+++ b/react-native-nitro-player/ios/media/MediaSessionManager.swift
@@ -31,7 +31,11 @@ class MediaSessionManager {
   // Cached values received from playerQueue — main-thread-only reads (no sync needed)
   private var cachedTrack: TrackItem?
   private var cachedState: PlayerState?
-  private var cachedQueue: [TrackItem] = []
+  // Only the queue length and the current track's position are needed — never the
+  // items themselves. Copying the whole queue on every state change was O(playlist)
+  // per event; these two Ints are computed on playerQueue instead.
+  private var cachedQueueCount: Int = 0
+  private var cachedPositionInQueue: Int = -1
 
   init() {
     setupRemoteCommandCenter()
@@ -56,10 +60,11 @@ class MediaSessionManager {
   //
   // Receives pre-computed values captured on playerQueue — no player access here.
 
-  func updateFromPlayerQueue(track: TrackItem, state: PlayerState, queue: [TrackItem]) {
+  func updateFromPlayerQueue(track: TrackItem, state: PlayerState, queueCount: Int, positionInQueue: Int) {
     cachedTrack = track
     cachedState = state
-    cachedQueue = queue
+    cachedQueueCount = queueCount
+    cachedPositionInQueue = positionInQueue
     refreshInternal()
   }
 
@@ -88,11 +93,10 @@ class MediaSessionManager {
       return
     }
 
-    let queue = cachedQueue
-    let positionInQueue = queue.firstIndex(where: { $0.id == track.id }) ?? -1
-
-    updateNowPlayingInfoInternal(track: track, state: state, queue: queue, positionInQueue: positionInQueue)
-    updateCommandCenterState(state: state, queue: queue, positionInQueue: positionInQueue)
+    updateNowPlayingInfoInternal(
+      track: track, state: state, queueCount: cachedQueueCount, positionInQueue: cachedPositionInQueue)
+    updateCommandCenterState(
+      state: state, queueCount: cachedQueueCount, positionInQueue: cachedPositionInQueue)
   }
 
   // MARK: - Now Playing Info
@@ -100,7 +104,7 @@ class MediaSessionManager {
   private func updateNowPlayingInfoInternal(
     track: TrackItem,
     state: PlayerState,
-    queue: [TrackItem],
+    queueCount: Int,
     positionInQueue: Int
   ) {
     let playerDuration = state.totalDuration
@@ -125,7 +129,7 @@ class MediaSessionManager {
       MPMediaItemPropertyPlaybackDuration: effectiveDuration,
       MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
       MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
-      MPNowPlayingInfoPropertyPlaybackQueueCount: max(1, queue.count),
+      MPNowPlayingInfoPropertyPlaybackQueueCount: max(1, queueCount),
       MPNowPlayingInfoPropertyPlaybackQueueIndex: max(0, positionInQueue),
     ]
 
@@ -238,12 +242,12 @@ class MediaSessionManager {
 
   private func updateCommandCenterState(
     state: PlayerState,
-    queue: [TrackItem],
+    queueCount: Int,
     positionInQueue: Int
   ) {
     let commandCenter = MPRemoteCommandCenter.shared()
     let hasCurrentTrack = positionInQueue >= 0
-    let isNotLast = positionInQueue < queue.count - 1
+    let isNotLast = positionInQueue < queueCount - 1
 
     let playerDuration = state.totalDuration
     let hasDuration = playerDuration > 0 && !playerDuration.isNaN && !playerDuration.isInfinite

--- a/react-native-nitro-player/ios/queue/HybridPlayerQueue.swift
+++ b/react-native-nitro-player/ios/queue/HybridPlayerQueue.swift
@@ -77,14 +77,19 @@ final class HybridPlayerQueue: HybridPlayerQueueSpec {
 
   // MARK: - Playback control
 
+  /// Enqueued synchronously on the player queue so a `loadPlaylist()` followed by
+  /// `play()` from JS cannot be reordered — see HybridTrackPlayer.enqueue.
   func loadPlaylist(playlistId: String, index: Double?) throws -> Promise<Void> {
-    Promise.async {
-      let startIndex = index.map { Int($0) }
+    let startIndex = index.map { Int($0) }
+    let promise = Promise<Void>()
+    core.playerQueue.async {
       // Update PlaylistManager.currentPlaylistId so getCurrentPlaylistId() returns correctly
-      let loaded = self.playlistManager.loadPlaylist(playlistId: playlistId, index: startIndex)
-      guard loaded else { return }
-      await self.core.loadPlaylist(playlistId: playlistId, startIndex: startIndex)
+      if self.playlistManager.loadPlaylist(playlistId: playlistId, index: startIndex) {
+        self.core.loadPlaylistOnQueue(playlistId: playlistId, startIndex: startIndex)
+      }
+      promise.resolve(withResult: ())
     }
+    return promise
   }
 
   func getCurrentPlaylistId() throws -> Variant_NullType_String {

--- a/react-native-nitro-player/src/components/CastButton.tsx
+++ b/react-native-nitro-player/src/components/CastButton.tsx
@@ -176,8 +176,20 @@ function CastGlyph({
         }}
       />
       {/* Two concentric broadcast arcs radiating from the corner dot */}
-      <RippleArc cx={cx} cy={cy} radius={size * 0.2} stroke={stroke} color={color} />
-      <RippleArc cx={cx} cy={cy} radius={size * 0.34} stroke={stroke} color={color} />
+      <RippleArc
+        cx={cx}
+        cy={cy}
+        radius={size * 0.2}
+        stroke={stroke}
+        color={color}
+      />
+      <RippleArc
+        cx={cx}
+        cy={cy}
+        radius={size * 0.34}
+        stroke={stroke}
+        color={color}
+      />
       {/* Broadcast dot */}
       <View
         style={{

--- a/react-native-nitro-player/src/hooks/callbackManager.ts
+++ b/react-native-nitro-player/src/hooks/callbackManager.ts
@@ -1,4 +1,4 @@
-import { TrackPlayer } from '../index'
+import { PlayerQueue, TrackPlayer } from '../index'
 import type { TrackItem, TrackPlayerState, Reason } from '../types/PlayerQueue'
 
 type PlaybackStateCallback = (state: TrackPlayerState, reason?: Reason) => void
@@ -9,6 +9,10 @@ type PlaybackProgressCallback = (
   isManuallySeeked?: boolean
 ) => void
 type SeekCallback = (position: number, totalDuration: number) => void
+type TemporaryQueueCallback = (
+  playNextQueue: TrackItem[],
+  upNextQueue: TrackItem[]
+) => void
 
 /**
  * Internal subscription manager that allows multiple hooks to subscribe
@@ -20,10 +24,14 @@ class CallbackSubscriptionManager {
   private trackChangeSubscribers = new Set<TrackChangeCallback>()
   private playbackProgressSubscribers = new Set<PlaybackProgressCallback>()
   private seekSubscribers = new Set<SeekCallback>()
+  private temporaryQueueSubscribers = new Set<TemporaryQueueCallback>()
+  private playlistsChangedSubscribers = new Set<() => void>()
+  private isPlaylistsChangedRegistered = false
   private isPlaybackStateRegistered = false
   private isTrackChangeRegistered = false
   private isPlaybackProgressRegistered = false
   private isSeekRegistered = false
+  private isTemporaryQueueRegistered = false
 
   /**
    * Subscribe to playback state changes
@@ -151,6 +159,82 @@ class CallbackSubscriptionManager {
     } catch (error) {
       console.error(
         '[CallbackManager] Failed to register playback progress callback:',
+        error
+      )
+    }
+  }
+
+  /**
+   * Subscribe to playNext / upNext changes
+   * @returns Unsubscribe function
+   */
+  subscribeToTemporaryQueueChange(callback: TemporaryQueueCallback): () => void {
+    this.temporaryQueueSubscribers.add(callback)
+    this.ensureTemporaryQueueRegistered()
+
+    return () => {
+      this.temporaryQueueSubscribers.delete(callback)
+    }
+  }
+
+  /**
+   * Subscribe to playlist mutations (tracks added/removed/reordered).
+   * @returns Unsubscribe function
+   */
+  subscribeToPlaylistsChanged(callback: () => void): () => void {
+    this.playlistsChangedSubscribers.add(callback)
+    this.ensurePlaylistsChangedRegistered()
+
+    return () => {
+      this.playlistsChangedSubscribers.delete(callback)
+    }
+  }
+
+  private ensurePlaylistsChangedRegistered(): void {
+    if (this.isPlaylistsChangedRegistered) return
+
+    try {
+      PlayerQueue.onPlaylistsChanged(() => {
+        this.playlistsChangedSubscribers.forEach((subscriber) => {
+          try {
+            subscriber()
+          } catch (error) {
+            console.error(
+              '[CallbackManager] Error in playlists changed subscriber:',
+              error
+            )
+          }
+        })
+      })
+      this.isPlaylistsChangedRegistered = true
+    } catch (error) {
+      console.error(
+        '[CallbackManager] Failed to register playlists changed callback:',
+        error
+      )
+    }
+  }
+
+  private ensureTemporaryQueueRegistered(): void {
+    if (this.isTemporaryQueueRegistered) return
+
+    try {
+      TrackPlayer.onTemporaryQueueChange((playNextQueue, upNextQueue) => {
+        this.temporaryQueueSubscribers.forEach((subscriber) => {
+          try {
+            subscriber(playNextQueue, upNextQueue)
+          } catch (error) {
+            console.error(
+              '[CallbackManager] Error in temporary queue subscriber:',
+              error
+            )
+          }
+        })
+      })
+      this.isTemporaryQueueRegistered = true
+    } catch (error) {
+      console.error(
+        '[CallbackManager] Failed to register temporary queue callback:',
         error
       )
     }

--- a/react-native-nitro-player/src/hooks/callbackManager.ts
+++ b/react-native-nitro-player/src/hooks/callbackManager.ts
@@ -168,7 +168,9 @@ class CallbackSubscriptionManager {
    * Subscribe to playNext / upNext changes
    * @returns Unsubscribe function
    */
-  subscribeToTemporaryQueueChange(callback: TemporaryQueueCallback): () => void {
+  subscribeToTemporaryQueueChange(
+    callback: TemporaryQueueCallback
+  ): () => void {
     this.temporaryQueueSubscribers.add(callback)
     this.ensureTemporaryQueueRegistered()
 

--- a/react-native-nitro-player/src/hooks/useActualQueue.ts
+++ b/react-native-nitro-player/src/hooks/useActualQueue.ts
@@ -89,27 +89,32 @@ export function useActualQueue(): UseActualQueueResult {
     }
   }, [updateQueue])
 
-  // Update queue on track changes (with slight delay to ensure native side has updated)
+  // Update queue on track changes.
+  //
+  // Deliberately NOT subscribed to playback-state changes: those fire several times
+  // per second while buffering or seeking, and each one used to pull the entire queue
+  // across the bridge. A playback state change never alters queue membership — only
+  // track changes and temporary-queue edits do.
   useEffect(() => {
-    const unsubscribe = callbackManager.subscribeToTrackChange(() => {
-      // Small delay to ensure native queue is updated
-      setTimeout(updateQueue, 50)
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [updateQueue])
-
-  // Update queue on playback state changes
-  useEffect(() => {
-    const unsubscribe = callbackManager.subscribeToPlaybackState(() => {
+    return callbackManager.subscribeToTrackChange(() => {
       updateQueue()
     })
+  }, [updateQueue])
 
-    return () => {
-      unsubscribe()
-    }
+  // Update queue when playNext / upNext change (native pushes the new lists).
+  useEffect(() => {
+    return callbackManager.subscribeToTemporaryQueueChange(() => {
+      updateQueue()
+    })
+  }, [updateQueue])
+
+  // Update queue when the playlist itself is edited (track added / removed / reordered).
+  // Without this, a playlist mutation while paused would leave the queue stale until the
+  // next track change — playback-state changes used to paper over it.
+  useEffect(() => {
+    return callbackManager.subscribeToPlaylistsChanged(() => {
+      updateQueue()
+    })
   }, [updateQueue])
 
   return { queue, refreshQueue, isLoading }

--- a/react-native-nitro-player/src/hooks/useNowPlaying.ts
+++ b/react-native-nitro-player/src/hooks/useNowPlaying.ts
@@ -88,12 +88,22 @@ export function useNowPlaying(): PlayerState {
     })
   }, [fetchFullState])
 
-  // Subscribe to progress changes — lightweight position/duration update
+  // Subscribe to progress changes — lightweight position/duration update.
+  // Bail out when neither value changed at whole-second resolution: the native tick
+  // is sub-second, and a new state object on every tick re-renders every consumer.
   useEffect(() => {
     return callbackManager.subscribeToPlaybackProgressChange(
       (currentPosition, totalDuration) => {
         if (!isMounted.current) return
-        setState((prev) => ({ ...prev, currentPosition, totalDuration }))
+        setState((prev) => {
+          if (
+            Math.floor(prev.currentPosition) === Math.floor(currentPosition) &&
+            prev.totalDuration === totalDuration
+          ) {
+            return prev
+          }
+          return { ...prev, currentPosition, totalDuration }
+        })
       }
     )
   }, [])


### PR DESCRIPTION
Queue mutation on a large playlist was O(playlist) on both platforms — every `playNext` / `addToUpNext` / `skipToIndex` destroyed and recreated a media item **per remaining track**. On iOS that meant `addToUpNext` took **22 seconds** on a 500-track queue. Separately, JS call order was not preserved into native, so ordered commands could execute reversed.

## Before vs after

500-track playlist, **Release** builds. iOS = iPhone 17 Pro simulator, Android = physical device (Release + R8).

### iOS

| operation | before | after | speedup |
|---|---:|---:|---:|
| `loadPlaylist(500)` | 141 ms | 7 ms | **20×** |
| `skipToIndex` (per call) | 437 ms | 3.7 ms | **118×** |
| `playNext` (per call) | 7 142 ms | 3.3 ms | **2 197×** |
| `addToUpNext` (per call) | 22 294 ms | 0.35 ms | **63 697×** |
| **full suite** | **597.6 s** | **0.17 s** | **3 515×** |

### Android

| operation | before | after | speedup |
|---|---:|---:|---:|
| `loadPlaylist(500)` | 48 ms | 18 ms | **2.7×** |
| `addToUpNext` (per call) | 37.6 ms | 2.1 ms | **18×** |
| `playNext` (per call) | 28.2 ms | 18.6 ms | **1.5×** |
| `getActualQueue` (per call) | 6.1 ms | 4.7 ms | **1.3×** |
| progress callbacks / 10 s | 42 | 6 | **7× fewer** |
| **full suite** | **2 242 ms** | **1 237 ms** | **1.8×** |

Numbers are reproducible via the harness added in `example/src/screens/BenchScreen.tsx` (flip `RUN_BENCH` in `example/App.tsx`; it auto-runs 3 s after mount and logs `[BENCH]` lines).

Two honest caveats: iOS `getActualQueue` is ~0.4 ms slower per call (run-to-run noise, not attributable to a change), and Android `skipToIndex` barely moved — that path is dominated by `getActualQueueInternal()` plus ExoPlayer's `clearMediaItems`/`setMediaItems`, neither of which windowing touches.

## What changed

### Windowed player queue
The logical queue (`currentTracks` + `playNextStack` + `upNextQueue`) is unchanged and `getActualQueue()` returns exactly what it did before. Only the *materialized* timeline is capped at current + 4, topped up on each item transition. Rebuilds became a longest-common-prefix diff: the matching prefix of already-buffered items is kept and only the divergent tail is recreated, so a pure top-up touches nothing already buffered and gapless survives.

### Ordered command dispatch
`Promise.async {}` starts an unordered `Task`/coroutine, so the hop onto the serial player queue happened at an arbitrary later point — `play()` then `pause()` from JS could land as pause-then-play. Both `HybridTrackPlayer`s now enqueue **synchronously on the JS thread at call time**, so the serial queue's FIFO order equals JS call order. Android buffers commands issued before the playback service binds and drains them in order.

### Thread-confinement fixes (iOS)
- `preloadUpcomingTracks` read `currentTracks` / `preloadedAssets` (Swift `Array`/`Dictionary`) from `preloadQueue` while `playerQueue` wrote them. Now snapshots on the owning queue before hopping.
- `isCasting` / `intendedToPlay` / `currentPlaybackSpeed` were read and written before the queue hop in `play`/`pause`/`seek`/`skipToNext`/`setVolume`/`setPlaybackSpeed`.
- The `isPlaybackBufferEmpty` KVO observer called `emitStateChange()` directly off the KVO thread (its sibling correctly hopped).
- `pendingPlaylistUpdateWorkItem` was mutated from `PlaylistManager`'s queue while `playerQueue` read it — replaced with a queue-owned generation counter.

### Cheaper hot paths
- `isTrackDownloaded` / `getLocalPath` hit the filesystem on **every** call, and queue building calls them once per track. Memoized per track ID on both platforms, invalidated on any record mutation.
- `notifyTrackChange` / `notifyPlaybackStateChange` built the entire queue just so `MediaSessionManager` could read `count` and `positionInQueue` — now computed arithmetically.
- `getNextTracks` / `checkUpcomingTracksForUrls` materialized the whole queue to read the next 5; now walk the structure directly.
- `useActualQueue` refetched the entire queue over JSI on every `onPlaybackStateChange` (fires several times per second while buffering). Now subscribes to track change, temporary-queue change, and playlist change — the signals that actually alter queue membership.
- `useNowPlaying` skips the state update when neither position nor duration changed at whole-second resolution.
- Android emitted progress every 250 ms even while paused; now 1 Hz and only while playing, matching iOS.

## Bugs fixed along the way

- **Android `getState().currentIndex` returned the wrong value.** It reported `exo.currentMediaItemIndex` — an index into the materialized timeline, which reads `0` after any jump — instead of the playlist index. Now matches iOS and the documented contract.
- **`BackgroundServiceStartNotAllowedException` crash.** `TrackPlayerCore.init` called `context.startService()` unguarded; on Android 12+ this hard-crashes any app whose JS loads the module while backgrounded. `BIND_AUTO_CREATE` already creates the service, so the call is now best-effort.
- **iOS main-thread stall.** `AVURLAsset.dealloc` blocks its thread inside `URLAssetFinalize` until in-flight `loadValuesAsynchronously` work finishes — and AVPlayer tears removed items down on the **main** thread, stalling `RCTTiming` so JS `setTimeout` stops firing entirely. Queue items no longer start async key loads; warm-up happens only in `preloadUpcomingTracks`, which publishes assets only once fully loaded. (`cancelLoading()` is *not* a workaround — it blocks too, and poisons cached assets into the failed-item retry path.)

## Testing

- Both platforms built in Release and run on device/simulator; benchmark suite completes end-to-end with **0 crashes**.
- `tsc --noEmit` clean; Kotlin and Swift compile clean.
- Reviewed the full diff against a 100-point checklist; fixed everything it surfaced, including Cast-queue truncation and top-up re-entrancy, then re-ran both benchmarks to confirm the fixes cost nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
