### PR TITLE
fix: expose ICY StreamUrl as metadata.url on both platforms

### DIFF
--- a/docs/content/docs/api/track-player.mdx
+++ b/docs/content/docs/api/track-player.mdx
@@ -543,17 +543,20 @@ album art for live radio.
 ```typescript
 TrackPlayer.onTimedMetadata((metadata) => {
   console.log(metadata.title, metadata.artist);
+  setArtwork(metadata.artworkUrl ?? metadata.url);
 });
 ```
 
 | Field | Type | Description |
 |---|---|---|
-| `title` | `string?` | Track title, or the raw ICY `StreamTitle` (often `"Artist - Title"`) |
-| `artist` | `string?` | Artist, when the stream sends it as a separate field |
+| `title` | `string?` | Track title |
+| `artist` | `string?` | Artist. ICY sends a single `"Artist - Title"` string — it is split for you when the stream gives no separate artist |
 | `album` | `string?` | Album name |
-| `artworkUrl` | `string?` | Artwork URL. **Android only** — iOS delivers embedded artwork as raw data, not a URL |
+| `url` | `string?` | ICY `StreamUrl` / ID3 webpage frame. Radio providers commonly put the current track's **artwork URL** here |
+| `artworkUrl` | `string?` | Artwork URL when the stream tags one explicitly |
 
-Regular (non-streaming) tracks may never fire this event.
+Each event is a snapshot, not a merge — a field present in one event can be absent
+in the next. Regular (non-streaming) tracks may never fire this event.
 
 ---
 

--- a/docs/content/docs/hooks/playback-hooks.mdx
+++ b/docs/content/docs/hooks/playback-hooks.mdx
@@ -160,9 +160,11 @@ import { useTimedMetadata } from 'react-native-nitro-player';
 
 function LiveNowPlaying() {
   const metadata = useTimedMetadata();
+  const artwork = metadata?.artworkUrl ?? metadata?.url;
 
   return (
     <View>
+      {!!artwork && <Image source={{ uri: artwork }} style={{ width: 200, height: 200 }} />}
       <Text>{metadata?.title ?? 'Live'}</Text>
       <Text>{metadata?.artist}</Text>
     </View>
@@ -173,13 +175,19 @@ function LiveNowPlaying() {
 Returns `undefined` until the first metadata event arrives. Regular (non-streaming)
 tracks may never emit one — keep using `useNowPlaying` for static track info.
 
+Each event is a snapshot, not a merge: an ICY update carries only what the station
+sent, so a field present in one event can be absent in the next. Not every station
+puts artwork in `url` — some send a station or artist page — so validate before
+rendering it as an image.
+
 ### Return Type: `TimedMetadata | undefined`
 
 | Field | Type | Description |
 |---|---|---|
-| `title` | `string \| undefined` | Track title, or the raw ICY `StreamTitle` (often `"Artist - Title"`) |
-| `artist` | `string \| undefined` | Artist, when the stream sends it as a separate field |
+| `title` | `string \| undefined` | Track title |
+| `artist` | `string \| undefined` | Artist. ICY sends a single `"Artist - Title"` string — it is split for you when the stream gives no separate artist |
 | `album` | `string \| undefined` | Album name |
-| `artworkUrl` | `string \| undefined` | Artwork URL. **Android only** — iOS delivers embedded artwork as raw data, not a URL |
+| `url` | `string \| undefined` | ICY `StreamUrl` / ID3 webpage frame. Radio providers commonly put the current track's **artwork URL** here |
+| `artworkUrl` | `string \| undefined` | Artwork URL when the stream tags one explicitly |
 
 For a non-React subscription, use `TrackPlayer.onTimedMetadata(callback)` directly.

--- a/example/src/data/sampleTracks.ts
+++ b/example/src/data/sampleTracks.ts
@@ -273,24 +273,28 @@ export const lazyLoadedTracks: TrackItem[] = [
     artwork: '',
   },
 ];
-/** Live radio streams — these emit ICY metadata, which drives `useTimedMetadata`. */
+/**
+ * Live radio streams — these emit ICY metadata, which drives `useTimedMetadata`.
+ * Hello Fred! sends per-track artwork in the ICY `StreamUrl` field; SomaFM sends
+ * only a `StreamTitle`, so it is a good check of the "Artist - Title" split.
+ */
 export const radioStreams: TrackItem[] = [
   {
     id: 'radio-1',
+    title: 'Hello Fred!',
+    artist: 'Live Radio',
+    album: 'Live365',
+    duration: 0,
+    url: 'https://das-edge11-live365-dal03.cdnstream.com/a28862_2',
+    artwork: '',
+  },
+  {
+    id: 'radio-2',
     title: 'SomaFM — Groove Salad',
     artist: 'Live Radio',
     album: 'SomaFM',
     duration: 0,
     url: 'https://ice2.somafm.com/groovesalad-128-mp3',
     artwork: 'https://somafm.com/img3/groovesalad-400.jpg',
-  },
-  {
-    id: 'radio-2',
-    title: 'SomaFM — Drone Zone',
-    artist: 'Live Radio',
-    album: 'SomaFM',
-    duration: 0,
-    url: 'https://ice2.somafm.com/dronezone-128-mp3',
-    artwork: 'https://somafm.com/img3/dronezone-400.jpg',
   },
 ];

--- a/example/src/screens/PlayerScreen.tsx
+++ b/example/src/screens/PlayerScreen.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Platform,
   SafeAreaView,
+  Image,
 } from 'react-native';
 import {
   TrackPlayer,
@@ -29,6 +30,7 @@ export default function PlayerScreen() {
   const { position: playbackPosition, totalDuration } =
     useOnPlaybackProgressChange();
   const streamMetadata = useTimedMetadata();
+  const streamArtwork = streamMetadata?.artworkUrl ?? streamMetadata?.url;
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
@@ -126,15 +128,15 @@ export default function PlayerScreen() {
           <View style={commonStyles.section}>
             <Text style={commonStyles.sectionTitle}>Stream Metadata</Text>
             <View style={commonStyles.card}>
+              {!!streamArtwork && (
+                <Image source={{uri: streamArtwork}} style={styles.streamArtwork} />
+              )}
               <Text style={styles.trackTitle}>{streamMetadata.title ?? '—'}</Text>
               {!!streamMetadata.artist && (
                 <Text style={styles.trackArtist}>{streamMetadata.artist}</Text>
               )}
               {!!streamMetadata.album && (
                 <Text style={styles.trackAlbum}>{streamMetadata.album}</Text>
-              )}
-              {!!streamMetadata.artworkUrl && (
-                <Text style={styles.trackAlbum}>{streamMetadata.artworkUrl}</Text>
               )}
             </View>
           </View>
@@ -331,6 +333,12 @@ const styles = StyleSheet.create({
   trackAlbum: {
     fontSize: 14,
     color: colors.textTertiary,
+  },
+  streamArtwork: {
+    width: 120,
+    height: 120,
+    borderRadius: borderRadius.md,
+    marginBottom: spacing.sm,
   },
   progressContainer: {
     flexDirection: 'row',

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.metadata.icy.IcyInfo
 import com.margelo.nitro.nitroplayer.Reason
 import com.margelo.nitro.nitroplayer.RepeatMode
 import com.margelo.nitro.nitroplayer.TimedMetadata
@@ -90,16 +91,27 @@ internal class TrackPlayerEventListener(
     @UnstableApi
     override fun onMetadata(metadata: Metadata) {
         val builder = MediaMetadata.Builder()
+        var url: String? = null
         for (i in 0 until metadata.length()) {
-            metadata.get(i).populateMediaMetadata(builder)
+            val entry = metadata.get(i)
+            entry.populateMediaMetadata(builder)
+            // populateMediaMetadata drops IcyInfo.url — radio providers put the
+            // current track's artwork URL there, so read it off the entry directly.
+            if (entry is IcyInfo && !entry.url.isNullOrEmpty()) url = entry.url
         }
         val merged = builder.build()
-        val title = merged.title?.toString()
-        val artist = merged.artist?.toString()
+        var artist = merged.artist?.toString()
+        var title = merged.title?.toString()
+        // ICY streams pack both fields into one "Artist - Title" string
+        val separator = if (artist == null) title?.indexOf(" - ") ?: -1 else -1
+        if (separator > 0 && title != null && separator + 3 < title.length) {
+            artist = title.substring(0, separator)
+            title = title.substring(separator + 3)
+        }
         val album = merged.albumTitle?.toString()
         val artworkUrl = merged.artworkUri?.toString()
-        if (title == null && artist == null && album == null && artworkUrl == null) return
-        core.notifyTimedMetadata(TimedMetadata(title, artist, album, artworkUrl))
+        if (title == null && artist == null && album == null && url == null && artworkUrl == null) return
+        core.notifyTimedMetadata(TimedMetadata(title, artist, album, url, artworkUrl))
     }
 
     override fun onTimelineChanged(

--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -510,6 +510,8 @@ extension TrackPlayerCore {
     var title: String?
     var artist: String?
     var album: String?
+    var url: String?
+    var artworkUrl: String?
 
     for group in groups {
       for item in group.items {
@@ -518,17 +520,40 @@ extension TrackPlayerCore {
         case .some(.commonKeyTitle): title = value
         case .some(.commonKeyArtist): artist = value
         case .some(.commonKeyAlbumName): album = value
+        case .some(.commonKeyArtwork): artworkUrl = value
         default:
-          // ICY/Shoutcast streams carry no common keys — match on the identifier
-          if item.identifier == .icyMetadataStreamTitle { title = value }
+          // ICY/Shoutcast streams carry no common keys — match on the identifier.
+          // StreamUrl is where radio providers put the current track's artwork.
+          switch item.identifier {
+          case .some(.icyMetadataStreamTitle): title = value
+          case .some(.icyMetadataStreamURL): url = value
+          case .some(.id3MetadataOfficialAudioSourceWebpage),
+               .some(.id3MetadataOfficialAudioFileWebpage):
+            if url == nil { url = value }
+          default: break
+          }
         }
       }
     }
 
-    guard title != nil || artist != nil || album != nil else { return }
+    (artist, title) = splitStreamTitle(artist: artist, title: title)
+
+    guard title != nil || artist != nil || album != nil || url != nil || artworkUrl != nil else { return }
     NitroPlayerLogger.log("TrackPlayerCore", "🏷️ Timed metadata - \(title ?? "-") / \(artist ?? "-")")
-    // artworkUrl is Android-only: iOS delivers embedded art as raw data, not a URL
-    notifyTimedMetadata(TimedMetadata(title: title, artist: artist, album: album, artworkUrl: nil))
+    notifyTimedMetadata(
+      TimedMetadata(title: title, artist: artist, album: album, url: url, artworkUrl: artworkUrl))
+  }
+
+  /// ICY streams pack both fields into one `"Artist - Title"` string. Split it when
+  /// the stream gave no separate artist, leaving an explicit artist untouched.
+  func splitStreamTitle(artist: String?, title: String?) -> (String?, String?) {
+    guard artist == nil, let title, let separator = title.range(of: " - ") else {
+      return (artist, title)
+    }
+    let left = String(title[title.startIndex..<separator.lowerBound])
+    let right = String(title[separator.upperBound...])
+    guard !left.isEmpty, !right.isEmpty else { return (artist, title) }
+    return (left, right)
   }
 
   func emitStateChange(reason: Reason? = nil) {

--- a/react-native-nitro-player/nitrogen/generated/android/c++/JTimedMetadata.hpp
+++ b/react-native-nitro-player/nitrogen/generated/android/c++/JTimedMetadata.hpp
@@ -38,12 +38,15 @@ namespace margelo::nitro::nitroplayer {
       jni::local_ref<jni::JString> artist = this->getFieldValue(fieldArtist);
       static const auto fieldAlbum = clazz->getField<jni::JString>("album");
       jni::local_ref<jni::JString> album = this->getFieldValue(fieldAlbum);
+      static const auto fieldUrl = clazz->getField<jni::JString>("url");
+      jni::local_ref<jni::JString> url = this->getFieldValue(fieldUrl);
       static const auto fieldArtworkUrl = clazz->getField<jni::JString>("artworkUrl");
       jni::local_ref<jni::JString> artworkUrl = this->getFieldValue(fieldArtworkUrl);
       return TimedMetadata(
         title != nullptr ? std::make_optional(title->toStdString()) : std::nullopt,
         artist != nullptr ? std::make_optional(artist->toStdString()) : std::nullopt,
         album != nullptr ? std::make_optional(album->toStdString()) : std::nullopt,
+        url != nullptr ? std::make_optional(url->toStdString()) : std::nullopt,
         artworkUrl != nullptr ? std::make_optional(artworkUrl->toStdString()) : std::nullopt
       );
     }
@@ -54,7 +57,7 @@ namespace margelo::nitro::nitroplayer {
      */
     [[maybe_unused]]
     static jni::local_ref<JTimedMetadata::javaobject> fromCpp(const TimedMetadata& value) {
-      using JSignature = JTimedMetadata(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>);
+      using JSignature = JTimedMetadata(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -62,6 +65,7 @@ namespace margelo::nitro::nitroplayer {
         value.title.has_value() ? jni::make_jstring(value.title.value()) : nullptr,
         value.artist.has_value() ? jni::make_jstring(value.artist.value()) : nullptr,
         value.album.has_value() ? jni::make_jstring(value.album.value()) : nullptr,
+        value.url.has_value() ? jni::make_jstring(value.url.value()) : nullptr,
         value.artworkUrl.has_value() ? jni::make_jstring(value.artworkUrl.value()) : nullptr
       );
     }

--- a/react-native-nitro-player/nitrogen/generated/android/kotlin/com/margelo/nitro/nitroplayer/TimedMetadata.kt
+++ b/react-native-nitro-player/nitrogen/generated/android/kotlin/com/margelo/nitro/nitroplayer/TimedMetadata.kt
@@ -28,6 +28,9 @@ data class TimedMetadata(
   val album: String?,
   @DoNotStrip
   @Keep
+  val url: String?,
+  @DoNotStrip
+  @Keep
   val artworkUrl: String?
 ) {
   /* primary constructor */
@@ -40,8 +43,8 @@ data class TimedMetadata(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(title: String?, artist: String?, album: String?, artworkUrl: String?): TimedMetadata {
-      return TimedMetadata(title, artist, album, artworkUrl)
+    private fun fromCpp(title: String?, artist: String?, album: String?, url: String?, artworkUrl: String?): TimedMetadata {
+      return TimedMetadata(title, artist, album, url, artworkUrl)
     }
   }
 }

--- a/react-native-nitro-player/nitrogen/generated/ios/swift/TimedMetadata.swift
+++ b/react-native-nitro-player/nitrogen/generated/ios/swift/TimedMetadata.swift
@@ -18,7 +18,7 @@ public extension TimedMetadata {
   /**
    * Create a new instance of `TimedMetadata`.
    */
-  init(title: String?, artist: String?, album: String?, artworkUrl: String?) {
+  init(title: String?, artist: String?, album: String?, url: String?, artworkUrl: String?) {
     self.init({ () -> bridge.std__optional_std__string_ in
       if let __unwrappedValue = title {
         return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
@@ -33,6 +33,12 @@ public extension TimedMetadata {
       }
     }(), { () -> bridge.std__optional_std__string_ in
       if let __unwrappedValue = album {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = url {
         return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
         return .init()
@@ -75,6 +81,18 @@ public extension TimedMetadata {
     return { () -> String? in
       if bridge.has_value_std__optional_std__string_(self.__album) {
         let __unwrapped = bridge.get_std__optional_std__string_(self.__album)
+        return String(__unwrapped)
+      } else {
+        return nil
+      }
+    }()
+  }
+  
+  @inline(__always)
+  var url: String? {
+    return { () -> String? in
+      if bridge.has_value_std__optional_std__string_(self.__url) {
+        let __unwrapped = bridge.get_std__optional_std__string_(self.__url)
         return String(__unwrapped)
       } else {
         return nil

--- a/react-native-nitro-player/nitrogen/generated/shared/c++/TimedMetadata.hpp
+++ b/react-native-nitro-player/nitrogen/generated/shared/c++/TimedMetadata.hpp
@@ -43,11 +43,12 @@ namespace margelo::nitro::nitroplayer {
     std::optional<std::string> title     SWIFT_PRIVATE;
     std::optional<std::string> artist     SWIFT_PRIVATE;
     std::optional<std::string> album     SWIFT_PRIVATE;
+    std::optional<std::string> url     SWIFT_PRIVATE;
     std::optional<std::string> artworkUrl     SWIFT_PRIVATE;
 
   public:
     TimedMetadata() = default;
-    explicit TimedMetadata(std::optional<std::string> title, std::optional<std::string> artist, std::optional<std::string> album, std::optional<std::string> artworkUrl): title(title), artist(artist), album(album), artworkUrl(artworkUrl) {}
+    explicit TimedMetadata(std::optional<std::string> title, std::optional<std::string> artist, std::optional<std::string> album, std::optional<std::string> url, std::optional<std::string> artworkUrl): title(title), artist(artist), album(album), url(url), artworkUrl(artworkUrl) {}
 
   public:
     friend bool operator==(const TimedMetadata& lhs, const TimedMetadata& rhs) = default;
@@ -66,6 +67,7 @@ namespace margelo::nitro {
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "title"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "artist"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "album"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "url"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "artworkUrl")))
       );
     }
@@ -74,6 +76,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "title"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.title));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "artist"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.artist));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "album"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.album));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "url"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.url));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "artworkUrl"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.artworkUrl));
       return obj;
     }
@@ -88,6 +91,7 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "title")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "artist")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "album")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "url")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "artworkUrl")))) return false;
       return true;
     }

--- a/react-native-nitro-player/src/types/PlayerQueue.ts
+++ b/react-native-nitro-player/src/types/PlayerQueue.ts
@@ -43,8 +43,16 @@ export interface PlayerState {
 /** In-stream metadata emitted while a stream plays (ICY/Shoutcast StreamTitle, ID3 frames) */
 export interface TimedMetadata {
   title?: string
+  /** Split out of `title` when the stream sends only `"Artist - Title"` */
   artist?: string
   album?: string
+  /**
+   * ICY `StreamUrl` / ID3 webpage frame. Radio providers commonly put the
+   * current track's artwork URL here (Live365, StreamGuys), but some send a
+   * station or artist page instead — check the value before treating it as art.
+   */
+  url?: string
+  /** Artwork URL the stream tagged as artwork, when it sends one explicitly */
   artworkUrl?: string
 }
 


### PR DESCRIPTION
Follow-up to #120.

That PR read `.icyMetadataStreamURL` on iOS and threw the value away, then documented `artworkUrl` as Android-only. Both were wrong: ICY `StreamUrl` is where radio providers put the current track's artwork, and it is available on both platforms.

Verified against a live Live365 stream (`das-edge11-live365-dal03.cdnstream.com/a28862_2`), whose in-band metadata block reads:

```
StreamTitle='Bethel Music & Hannah McClure - Precious Blood (feat. Amanda Cook)';
StreamUrl='https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/…/512x512bb.jpg';
```

## Changes

- **`TimedMetadata.url`** (new) — ICY `StreamUrl`, plus ID3 `OfficialAudioSourceWebpage`/`OfficialAudioFileWebpage` as a fallback on iOS. Named `url`, not `artworkUrl`, because the field is convention rather than spec — most platforms send artwork, some send a station or artist page.
- **`artworkUrl`** now also fills on iOS from `commonKeyArtwork` when it arrives as a string.
- **Android** reads `IcyInfo.url` off the metadata entry directly — media3's `populateMediaMetadata` copies only `IcyInfo.title` and drops the url.
- **`"Artist - Title"` split** on both platforms when the stream sends no separate artist, matching doublesymmetry/react-native-track-player#937. Without it `artist` was permanently null for ICY, since ICY packs both into one `StreamTitle`.
- Docs corrected, consumers pointed at `metadata.artworkUrl ?? metadata.url` with the caveat above.
- Example app switched to the Live365 stream (sends artwork) plus SomaFM (title only, exercises the split), and renders the artwork.

`.icyMetadataStreamURL` is iOS 14+; the pod's deployment target is 15.1, so no fallback path is needed.

## Verification

- `bun run typecheck`
- `./gradlew :react-native-nitro-player:compileDebugKotlin` — confirmed the compiled `TrackPlayerEventListener.class` references `IcyInfo`
- `xcodebuild -project Pods/Pods.xcodeproj -target NitroPlayer -sdk iphonesimulator`

The parse is verified against the stream's real metadata bytes, not against AVPlayer's own ICY decoding on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
