### PR TITLE
fix: stop permanent native listener leaks in useOnSeek, useAndroidAutoConnection, usePlaylist

### DIFF
--- a/react-native-nitro-player/src/hooks/callbackManager.ts
+++ b/react-native-nitro-player/src/hooks/callbackManager.ts
@@ -19,6 +19,7 @@ type TemporaryQueueCallback = (
   playNextQueue: TrackItem[],
   upNextQueue: TrackItem[]
 ) => void
+type AndroidAutoConnectionCallback = (connected: boolean) => void
 
 /**
  * Internal subscription manager that allows multiple hooks to subscribe
@@ -33,7 +34,10 @@ class CallbackSubscriptionManager {
   private timedMetadataSubscribers = new Set<TimedMetadataCallback>()
   private temporaryQueueSubscribers = new Set<TemporaryQueueCallback>()
   private playlistsChangedSubscribers = new Set<() => void>()
+  private androidAutoConnectionSubscribers =
+    new Set<AndroidAutoConnectionCallback>()
   private isPlaylistsChangedRegistered = false
+  private isAndroidAutoConnectionRegistered = false
   private isPlaybackStateRegistered = false
   private isTrackChangeRegistered = false
   private isPlaybackProgressRegistered = false
@@ -267,6 +271,46 @@ class CallbackSubscriptionManager {
     } catch (error) {
       console.error(
         '[CallbackManager] Failed to register seek callback:',
+        error
+      )
+    }
+  }
+
+  /**
+   * Subscribe to Android Auto connection changes
+   * @returns Unsubscribe function
+   */
+  subscribeToAndroidAutoConnection(
+    callback: AndroidAutoConnectionCallback
+  ): () => void {
+    this.androidAutoConnectionSubscribers.add(callback)
+    this.ensureAndroidAutoConnectionRegistered()
+
+    return () => {
+      this.androidAutoConnectionSubscribers.delete(callback)
+    }
+  }
+
+  private ensureAndroidAutoConnectionRegistered(): void {
+    if (this.isAndroidAutoConnectionRegistered) return
+
+    try {
+      TrackPlayer.onAndroidAutoConnectionChange((connected) => {
+        this.androidAutoConnectionSubscribers.forEach((subscriber) => {
+          try {
+            subscriber(connected)
+          } catch (error) {
+            console.error(
+              '[CallbackManager] Error in Android Auto connection subscriber:',
+              error
+            )
+          }
+        })
+      })
+      this.isAndroidAutoConnectionRegistered = true
+    } catch (error) {
+      console.error(
+        '[CallbackManager] Failed to register Android Auto connection callback:',
         error
       )
     }

--- a/react-native-nitro-player/src/hooks/useAndroidAutoConnection.ts
+++ b/react-native-nitro-player/src/hooks/useAndroidAutoConnection.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { TrackPlayer } from '../index'
+import { callbackManager } from './callbackManager'
 
 /**
  * Hook to detect Android Auto connection status using the official Android for Cars API
@@ -15,15 +16,14 @@ export function useAndroidAutoConnection() {
   const [isConnected, setIsConnected] = useState<boolean>(false)
 
   useEffect(() => {
-    // Set initial state
     const initialState = TrackPlayer.isAndroidAutoConnected()
     setIsConnected(initialState)
 
-    // Listen for connection changes
-    TrackPlayer.onAndroidAutoConnectionChange((connected: boolean) => {
-      setIsConnected(connected)
-      console.log('🚗 Android Auto connection changed:', connected)
-    })
+    return callbackManager.subscribeToAndroidAutoConnection(
+      (connected: boolean) => {
+        setIsConnected(connected)
+      }
+    )
   }, [])
 
   return { isConnected }

--- a/react-native-nitro-player/src/hooks/useOnSeek.ts
+++ b/react-native-nitro-player/src/hooks/useOnSeek.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { TrackPlayer } from '../index'
+import { callbackManager } from './callbackManager'
 
 /**
  * Hook to get the last seek event information
@@ -15,7 +15,7 @@ export function useOnSeek(): {
   )
 
   useEffect(() => {
-    TrackPlayer.onSeek((newPosition, newTotalDuration) => {
+    return callbackManager.subscribeToSeek((newPosition, newTotalDuration) => {
       setPosition(newPosition)
       setTotalDuration(newTotalDuration)
     })

--- a/react-native-nitro-player/src/hooks/usePlaylist.ts
+++ b/react-native-nitro-player/src/hooks/usePlaylist.ts
@@ -59,7 +59,6 @@ export function usePlaylist(): UsePlaylistResult {
   const [allTracks, setAllTracks] = useState<TrackItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const isMounted = useRef(true)
-  const hasSubscribed = useRef(false)
   // Tracks the last fetched playlist ID so track-change events can skip
   // a full refresh when the playlist itself hasn't changed.
   const lastPlaylistIdRef = useRef<string | null | undefined>(undefined)
@@ -143,20 +142,13 @@ export function usePlaylist(): UsePlaylistResult {
     }
   }, [refreshPlaylists])
 
-  // Subscribe to native playlist changes (only once)
+  // Subscribe to native playlist changes via the shared manager
   useEffect(() => {
-    if (hasSubscribed.current) return
-    hasSubscribed.current = true
-
-    try {
-      PlayerQueue.onPlaylistsChanged(() => {
-        if (isMounted.current) {
-          refreshPlaylists()
-        }
-      })
-    } catch (error) {
-      console.error('[usePlaylist] Error setting up playlist listener:', error)
-    }
+    return callbackManager.subscribeToPlaylistsChanged(() => {
+      if (isMounted.current) {
+        refreshPlaylists()
+      }
+    })
   }, [refreshPlaylists])
 
   // Refresh on track change only if the active playlist ID changed.


### PR DESCRIPTION
## Problem
Three hooks register native callbacks directly instead of going through `callbackManager`:

- `useOnSeek` — `TrackPlayer.onSeek()` per mount, never removed. Native side adds a listener per call and only removes at deinit (which never runs for the JS singleton). N mounts = N permanent native→JS callbacks per seek, with setState on unmounted components.
- `useAndroidAutoConnection` — on Android each registration **replaces** the previous listener, so a second mounted instance silently freezes the first one's `isConnected`. Also leaked on unmount, plus a stray production `console.log`.
- `usePlaylist` — per-instance `hasSubscribed` ref meant every instance added another permanent native listener whose callback serializes the **entire playlists array** across the bridge on every playlist mutation.

## Fix
Route all three through the shared `callbackManager` (single native registration, fan-out with proper unsubscribe). Added `subscribeToAndroidAutoConnection` to the manager. Deleted the dead `hasSubscribed` ref and the console.log.

Agreed list RC-1 #1 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)