### PR TITLE
fix: iOS item notifications act on foreign players' items + off-queue state read

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -169,9 +169,11 @@ extension TrackPlayerCore {
   func playerItemDidPlayToEndTimeInternal(_ notification: Notification) {
     NitroPlayerLogger.log("TrackPlayerCore", "\n🏁 Track finished playing")
     guard let finishedItem = notification.object as? AVPlayerItem else { return }
+    // Items without our trackId belong to another AVPlayer in the host app
+    guard finishedItem.trackId != nil else { return }
 
     // 1. TRACK repeat — handle FIRST, before any temp-track removal
-    if currentRepeatMode == .track {
+    if currentRepeatMode == .track, finishedItem === player?.currentItem {
       NitroPlayerLogger.log("TrackPlayerCore", "🔁 TRACK repeat — seeking to zero and replaying")
       player?.seek(to: .zero)
       player?.play()
@@ -201,14 +203,18 @@ extension TrackPlayerCore {
   }
 
   @objc func playerItemFailedToPlayToEndTime(_ notification: Notification) {
-    if let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error {
+    guard (notification.object as? AVPlayerItem)?.trackId != nil else { return }
+    guard let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
+    else { return }
+    playerQueue.async { [weak self] in
       NitroPlayerLogger.log("TrackPlayerCore", "❌ Playback failed - \(error)")
-      notifyPlaybackStateChange(.stopped, .error)
+      self?.notifyPlaybackStateChange(.stopped, .error)
     }
   }
 
   @objc func playerItemNewErrorLogEntry(_ notification: Notification) {
-    guard let item = notification.object as? AVPlayerItem, let errorLog = item.errorLog() else { return }
+    guard let item = notification.object as? AVPlayerItem, item.trackId != nil,
+      let errorLog = item.errorLog() else { return }
     for event in errorLog.events ?? [] {
       NitroPlayerLogger.log("TrackPlayerCore", "❌ Error log - \(event.errorComment ?? "Unknown error") - Code: \(event.errorStatusCode)")
     }
@@ -220,6 +226,7 @@ extension TrackPlayerCore {
   @objc func playerItemTimeJumped(_ notification: Notification) {
     playerQueue.async { [weak self] in
       guard let self, let player = self.player, let currentItem = player.currentItem else { return }
+      guard (notification.object as? AVPlayerItem) === currentItem else { return }
       let position = currentItem.currentTime().seconds
       let duration = currentItem.duration.seconds
       NitroPlayerLogger.log("TrackPlayerCore", "🎯 Time jumped (seek detected) - position: \(Int(position))s")


### PR DESCRIPTION
## Problems (agreed list RC-2 #5 + #6, same handlers)

1. All AVPlayerItem notifications are registered with `object: nil`, and only the stalled handler checked ownership. When the host app plays anything through its own AVPlayer (video ad, react-native-video, preview clip):
   - with repeat `.track`, the foreign item finishing triggered `player?.seek(.zero); player?.play()` — nitro-player hijacked audio and force-played
   - a foreign item failing emitted a spurious `.stopped/.error` state to JS
   - a foreign seek emitted a bogus `onSeek` and set `isManuallySeeked`

2. `playerItemFailedToPlayToEndTime` called `notifyPlaybackStateChange` directly on AVFoundation's notification thread, reading playerQueue-owned arrays (`currentTracks`, temp queues) — CoW torn-read/crash risk during concurrent queue mutations.

## Fix
- `DidPlayToEndTime`: bail unless the item carries our `trackId`; repeat-track branch additionally requires `finishedItem === player?.currentItem`
- `FailedToPlayToEndTime`: `trackId` guard + body wrapped in `playerQueue.async` (same pattern as the stalled handler)
- `TimeJumped`: item must be our player's `currentItem`
- `NewErrorLogEntry`: `trackId` guard (log noise only)

Stacked on #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)