### PR TITLE
fix: Android downloads retried twice concurrently, corrupting the destination file

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -125,7 +125,7 @@ class DownloadManagerCore private constructor(
                 .addTag("track_${track.id}")
                 .build()
 
-        workManager.enqueue(downloadRequest)
+        workManager.enqueueUniqueWork("download_$downloadId", ExistingWorkPolicy.KEEP, downloadRequest)
 
         // Update state
         activeTasks[downloadId]?.state = DownloadState.PENDING
@@ -184,7 +184,7 @@ class DownloadManagerCore private constructor(
                     .addTag("track_${track.id}")
                     .build()
 
-            workManager.enqueue(downloadRequest)
+            workManager.enqueueUniqueWork("download_$downloadId", ExistingWorkPolicy.KEEP, downloadRequest)
 
             metadata.state = DownloadState.DOWNLOADING
             notifyStateChange(downloadId, metadata.trackId, DownloadState.DOWNLOADING, null)
@@ -407,25 +407,29 @@ class DownloadManagerCore private constructor(
         }
     }
 
+    // Retries are owned by WorkManager (Result.retry in DownloadWorker); this
+    // only records state so a second, competing worker is never scheduled here.
     internal fun onError(
         downloadId: String,
         trackId: String,
         error: DownloadError,
+        willRetry: Boolean = false,
     ) {
         activeTasks[downloadId]?.let { metadata ->
-            metadata.state = DownloadState.FAILED
             metadata.error = error
 
-            // Auto-retry if enabled
-            if (config.autoRetry == true && error.isRetryable && metadata.retryCount < (config.maxRetryAttempts?.toInt() ?: 3)) {
-                mainHandler.postDelayed({
-                    retryDownload(downloadId)
-                }, 2000)
+            if (willRetry) {
+                metadata.retryCount++
+                metadata.state = DownloadState.PENDING
             } else {
+                metadata.state = DownloadState.FAILED
                 notifyStateChange(downloadId, trackId, DownloadState.FAILED, error)
             }
         }
     }
+
+    internal fun maxWorkerRetryAttempts(): Int =
+        if (config.autoRetry == true) (config.maxRetryAttempts?.toInt() ?: 3) else 0
 
     private fun notifyStateChange(
         downloadId: String,

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
@@ -101,9 +101,7 @@ class DownloadWorker(
                             reason = DownloadErrorReason.UNKNOWN,
                             isRetryable = true,
                         )
-                    downloadManager.onError(downloadId, trackId, error)
-                    showErrorNotification(trackTitle)
-                    Result.retry()
+                    handleError(downloadId, trackId, trackTitle, error)
                 }
             } catch (e: TimeoutCancellationException) {
                 val error =
@@ -113,9 +111,7 @@ class DownloadWorker(
                         reason = DownloadErrorReason.TIMEOUT,
                         isRetryable = true,
                     )
-                downloadManager.onError(downloadId, trackId, error)
-                showErrorNotification(trackTitle)
-                Result.retry()
+                handleError(downloadId, trackId, trackTitle, error)
             } catch (e: Exception) {
                 val errorReason =
                     when {
@@ -132,16 +128,23 @@ class DownloadWorker(
                         reason = errorReason,
                         isRetryable = errorReason in listOf(DownloadErrorReason.NETWORK_ERROR, DownloadErrorReason.TIMEOUT),
                     )
-                downloadManager.onError(downloadId, trackId, error)
-                showErrorNotification(trackTitle)
-
-                if (error.isRetryable) {
-                    Result.retry()
-                } else {
-                    Result.failure()
-                }
+                handleError(downloadId, trackId, trackTitle, error)
             }
         }
+
+    // Single retry owner: WorkManager reschedules via Result.retry(); the manager
+    // only records state, never enqueues a competing request.
+    private fun handleError(
+        downloadId: String,
+        trackId: String,
+        trackTitle: String,
+        error: DownloadError,
+    ): Result {
+        val willRetry = error.isRetryable && runAttemptCount < downloadManager.maxWorkerRetryAttempts()
+        downloadManager.onError(downloadId, trackId, error, willRetry)
+        showErrorNotification(trackTitle)
+        return if (willRetry) Result.retry() else Result.failure()
+    }
 
     private suspend fun downloadFile(
         downloadId: String,


### PR DESCRIPTION
## Problem
On a retryable error `DownloadWorker` both returned `Result.retry()` (WorkManager reschedules with backoff) **and** called `downloadManager.onError`, which — with `autoRetry` defaulting to true — scheduled its own `retryDownload` → `workManager.enqueue(new request)` 2 s later. Two workers then downloaded the same track concurrently into the same deterministic destination file: interleaved writes, corrupted file, doubled bandwidth, broken `retryCount` bookkeeping.

## Fix
- WorkManager is now the single retry owner: the worker computes `willRetry = error.isRetryable && runAttemptCount < maxWorkerRetryAttempts()` (respects `autoRetry`/`maxRetryAttempts` config) and returns `Result.retry()` / `Result.failure()` accordingly.
- `onError` only records state: on `willRetry` it bumps `retryCount` and keeps the task `PENDING`; otherwise it marks `FAILED` and notifies. It never enqueues.
- Both enqueue sites now use `enqueueUniqueWork("download_$downloadId", ExistingWorkPolicy.KEEP, …)` so duplicate requests for the same download collapse.

Manual `retryDownload()` (public API) is unchanged.

Stacked on #127. Agreed list RC-4 #16 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)