### PR TITLE
fix: force-unwrap crash on optional wifiOnlyDownloads (iOS)

### DIFF
--- a/react-native-nitro-player/ios/download/DownloadManagerCore.swift
+++ b/react-native-nitro-player/ios/download/DownloadManagerCore.swift
@@ -42,7 +42,7 @@ final class DownloadManagerCore: NSObject {
       withIdentifier: Self.backgroundSessionIdentifier)
     configuration.isDiscretionary = false
     configuration.sessionSendsLaunchEvents = true
-    configuration.allowsCellularAccess = !config.wifiOnlyDownloads!
+    configuration.allowsCellularAccess = !(config.wifiOnlyDownloads ?? false)
     return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
   }()
 


### PR DESCRIPTION
## Problem
`configuration.allowsCellularAccess = !config.wifiOnlyDownloads!` force-unwraps an optional `DownloadConfig` field. Calling `configure()` with `wifiOnlyDownloads` unset crashes on the first touch of the lazy `backgroundSession` (first `downloadTrack`/`restorePendingDownloads`).

## Fix
`!(config.wifiOnlyDownloads ?? false)` — matches the nil-safe handling already used at line 95.

Stacked on #130. Agreed list RC-4 #18 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)