### PR TITLE
fix: Android playlists never restored after process death

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
@@ -59,7 +59,8 @@ class PlaylistManager private constructor(
     }
 
     init {
-        // Don't load from file on init - only load when Android Auto needs it
+        // Synchronous so no mutation can race a late async load and be clobbered
+        loadPlaylistsFromFile()
     }
 
     /**
@@ -75,10 +76,7 @@ class PlaylistManager private constructor(
 
         playlists[id] = playlist
 
-        // Only cache for Android Auto if connected
-        if (NitroPlayerMediaBrowserService.isAndroidAutoConnected) {
-            scheduleSave()
-        }
+        scheduleSave()
         notifyPlaylistsChanged(QueueOperation.ADD)
         NitroPlayerMediaBrowserService.getInstance()?.onPlaylistsUpdated()
 
@@ -96,10 +94,7 @@ class PlaylistManager private constructor(
                 currentPlaylistId = null
             }
             playlistListeners.remove(playlistId)
-            // Only cache for Android Auto if connected
-            if (NitroPlayerMediaBrowserService.isAndroidAutoConnected) {
-                scheduleSave()
-            }
+            scheduleSave()
             notifyPlaylistsChanged(QueueOperation.REMOVE)
             NitroPlayerMediaBrowserService.getInstance()?.onPlaylistsUpdated()
             return true
@@ -125,10 +120,7 @@ class PlaylistManager private constructor(
                 artwork = artwork ?: playlist.artwork,
             )
 
-        // Only cache for Android Auto if connected
-        if (NitroPlayerMediaBrowserService.isAndroidAutoConnected) {
-            scheduleSave()
-        }
+        scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.UPDATE)
         notifyPlaylistsChanged(QueueOperation.UPDATE)
         NitroPlayerMediaBrowserService.getInstance()?.onPlaylistsUpdated()
@@ -163,10 +155,7 @@ class PlaylistManager private constructor(
         }
         playlists[playlistId] = playlist.copy(tracks = tracks)
 
-        // Only cache for Android Auto if connected
-        if (NitroPlayerMediaBrowserService.isAndroidAutoConnected) {
-            scheduleSave()
-        }
+        scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.ADD)
         NitroPlayerMediaBrowserService.getInstance()?.onPlaylistUpdated(playlistId)
         return true
@@ -189,10 +178,7 @@ class PlaylistManager private constructor(
         }
         playlists[playlistId] = playlist.copy(tracks = currentTracks)
 
-        // Only cache for Android Auto if connected
-        if (NitroPlayerMediaBrowserService.isAndroidAutoConnected) {
-            scheduleSave()
-        }
+        scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.ADD)
         NitroPlayerMediaBrowserService.getInstance()?.onPlaylistUpdated(playlistId)
         return true


### PR DESCRIPTION
## Problem
- `loadPlaylistsFromFile()` had **zero callers** — after ordinary process death `PlaylistManager` started empty; persisted playlists and `currentPlaylistId` were never loaded back.
- Most mutations (create, delete, metadata update, add track/tracks) only called `scheduleSave()` while **Android Auto was connected**, so for typical phone use they were never persisted at all.
- Downstream: `DownloadDatabase` looks up the original playlist in the (empty) manager, so downloaded-playlist queries returned `null` after restart.

## Fix
- Load playlists synchronously in `init` — the singleton constructor runs once, and a synchronous load means no mutation can race a late async load and get clobbered.
- `scheduleSave()` now runs unconditionally on every successful mutation (the existing 300 ms debounce keeps IO cheap). Android Auto gating removed.

Stacked on #132. Agreed list RC-3 #12 / Codex finding A (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)