### PR TITLE
fix: completed Android downloads silently discarded after process death

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -115,6 +115,7 @@ class DownloadManagerCore private constructor(
                 DownloadWorker.KEY_URL to track.url,
                 DownloadWorker.KEY_PLAYLIST_ID to (playlistId ?: ""),
                 DownloadWorker.KEY_STORAGE_LOCATION to (config.storageLocation?.name ?: StorageLocation.PRIVATE.name),
+                DownloadWorker.KEY_TRACK_JSON to TrackItemJson.toJson(track),
             )
 
         val downloadRequest =
@@ -375,8 +376,11 @@ class DownloadManagerCore private constructor(
         downloadId: String,
         trackId: String,
         localPath: String,
+        fallbackTrack: TrackItem? = null,
     ) {
-        val track = trackMetadata[trackId] ?: return
+        // fallbackTrack comes from the worker's persisted inputData — the
+        // in-memory maps are empty when the worker completes in a fresh process.
+        val track = trackMetadata[trackId] ?: fallbackTrack ?: return
         val playlistId = playlistAssociations[downloadId]
         val storageLocation = config.storageLocation ?: StorageLocation.PRIVATE
         val fileSize = fileManager.getFileSize(localPath)

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -175,6 +175,7 @@ class DownloadManagerCore private constructor(
                     DownloadWorker.KEY_URL to track.url,
                     DownloadWorker.KEY_PLAYLIST_ID to (playlistId ?: ""),
                     DownloadWorker.KEY_STORAGE_LOCATION to (config.storageLocation?.name ?: StorageLocation.PRIVATE.name),
+                    DownloadWorker.KEY_TRACK_JSON to TrackItemJson.toJson(track),
                 )
 
             val downloadRequest =

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
@@ -36,6 +36,7 @@ class DownloadWorker(
         const val KEY_URL = "url"
         const val KEY_PLAYLIST_ID = "playlist_id"
         const val KEY_STORAGE_LOCATION = "storage_location"
+        const val KEY_TRACK_JSON = "track_json"
 
         private const val NOTIFICATION_CHANNEL_ID = "nitro_player_downloads"
         private const val BASE_NOTIFICATION_ID = 2001
@@ -93,7 +94,8 @@ class DownloadWorker(
                     }
 
                 if (localPath != null) {
-                    downloadManager.onComplete(downloadId, trackId, localPath)
+                    val fallbackTrack = inputData.getString(KEY_TRACK_JSON)?.let { TrackItemJson.fromJson(it) }
+                    downloadManager.onComplete(downloadId, trackId, localPath, fallbackTrack)
                     showCompletionNotification(trackTitle)
                     Result.success()
                 } else {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/TrackItemJson.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/TrackItemJson.kt
@@ -1,0 +1,60 @@
+package com.margelo.nitro.nitroplayer.download
+
+import com.margelo.nitro.core.AnyMap
+import com.margelo.nitro.nitroplayer.TrackItem
+import com.margelo.nitro.nitroplayer.Variant_NullType_String
+import org.json.JSONObject
+
+// Survives process death inside the worker's inputData so a completed
+// download can be recorded even when the in-memory metadata maps are gone.
+internal object TrackItemJson {
+    fun toJson(track: TrackItem): String =
+        JSONObject()
+            .apply {
+                put("id", track.id)
+                put("title", track.title)
+                put("artist", track.artist)
+                put("album", track.album)
+                put("duration", track.duration)
+                put("url", track.url)
+                track.artwork?.asSecondOrNull()?.let { put("artwork", it) }
+                track.extraPayload?.let { payload ->
+                    put("extraPayload", JSONObject(payload.toHashMap()))
+                }
+            }.toString()
+
+    fun fromJson(json: String): TrackItem? =
+        try {
+            val obj = JSONObject(json)
+            val artworkStr = obj.optString("artwork")
+            val extraPayload: AnyMap? =
+                if (obj.has("extraPayload")) {
+                    val extraObj = obj.getJSONObject("extraPayload")
+                    val map = AnyMap()
+                    val keys = extraObj.keys()
+                    while (keys.hasNext()) {
+                        val key = keys.next()
+                        when (val value = extraObj.get(key)) {
+                            is String -> map.setString(key, value)
+                            is Number -> map.setDouble(key, value.toDouble())
+                            is Boolean -> map.setBoolean(key, value)
+                        }
+                    }
+                    map
+                } else {
+                    null
+                }
+            TrackItem(
+                id = obj.getString("id"),
+                title = obj.getString("title"),
+                artist = obj.getString("artist"),
+                album = obj.getString("album"),
+                duration = obj.getDouble("duration"),
+                url = obj.getString("url"),
+                artwork = if (artworkStr.isNullOrEmpty()) null else Variant_NullType_String.create(artworkStr),
+                extraPayload = extraPayload,
+            )
+        } catch (e: Exception) {
+            null
+        }
+}


### PR DESCRIPTION
## Problem
WorkManager persists queued work across process death, but `trackMetadata`/`activeTasks`/`playlistAssociations` are in-memory only. When a worker completed in a fresh process, `onComplete` early-returned (`trackMetadata[trackId] ?: return`): the file was on disk but never saved to `DownloadDatabase`, no callbacks fired, and the next `syncDownloads()`/`cleanupOrphanedFiles()` deleted it as an orphan. Queue an album, swipe the app away → the finished bytes were silently thrown away.

## Fix
- Serialize the full `TrackItem` into the worker's persisted `inputData` (`KEY_TRACK_JSON`, new `TrackItemJson` helper mirroring the PlaylistManager JSON round-trip incl. artwork + extraPayload).
- On completion the worker passes the deserialized track as a fallback; `onComplete` uses `trackMetadata[trackId] ?: fallbackTrack` so the record is written even when the in-memory maps are gone.

Both enqueue sites (initial + resume) carry the JSON.

Stacked on #133. Agreed list RC-3 #13 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)