### PR TITLE
fix: Android DownloadDatabase concurrent disk writes can persist a stale snapshot

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
@@ -8,6 +8,7 @@ import com.margelo.nitro.nitroplayer.core.NitroPlayerLogger
 import com.margelo.nitro.nitroplayer.playlist.PlaylistManager
 import com.margelo.nitro.nitroplayer.storage.NitroPlayerStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -50,7 +51,9 @@ class DownloadDatabase private constructor(
     private val existenceCache = mutableMapOf<String, Boolean>()
     private val playlistTracks = mutableMapOf<String, MutableSet<String>>()
     private val fileManager = DownloadFileManager.getInstance(context)
-    private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    // Single-threaded so rapid saves cannot land out of order and persist a stale snapshot
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val ioScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
 
     init {
         loadFromDisk()


### PR DESCRIPTION
## Problem
Every mutation launches `ioScope.launch { … write … }` on parallel `Dispatchers.IO`. Two rapid mutations (finishing a playlist download, delete-then-save) can complete out of order, so the **older** snapshot wins on disk and the newer record is lost after the next app start.

## Fix
`Dispatchers.IO.limitedParallelism(1)` — writes run in launch order on a single lane. One line.

Stacked on #134. Agreed list RC-3 #14 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)