### PR TITLE
fix: iOS pauseDownload writes resume data off the isolation queue

### DIFF
--- a/react-native-nitro-player/ios/download/DownloadManagerCore.swift
+++ b/react-native-nitro-player/ios/download/DownloadManagerCore.swift
@@ -180,8 +180,10 @@ final class DownloadManagerCore: NSObject {
       guard let task = self.activeTasks[downloadId] else { return }
 
       task.cancel(byProducingResumeData: { resumeData in
-        // Store resume data for later
-        self.taskMetadata[downloadId]?.resumeData = resumeData
+        // Runs on the URLSession delegate queue — hop back for the shared dict
+        self.queue.async(flags: .barrier) {
+          self.taskMetadata[downloadId]?.resumeData = resumeData
+        }
       })
 
       self.taskMetadata[downloadId]?.state = .paused
@@ -264,7 +266,9 @@ final class DownloadManagerCore: NSObject {
   private func _pauseDownloadUnsafe(downloadId: String) {
     guard let task = self.activeTasks[downloadId] else { return }
     task.cancel(byProducingResumeData: { resumeData in
-      self.taskMetadata[downloadId]?.resumeData = resumeData
+      self.queue.async(flags: .barrier) {
+        self.taskMetadata[downloadId]?.resumeData = resumeData
+      }
     })
     self.taskMetadata[downloadId]?.state = .paused
     if let trackId = self.taskMetadata[downloadId]?.trackId {


### PR DESCRIPTION
## Problem
`task.cancel(byProducingResumeData:)`'s completion runs on the URLSession delegate queue and wrote `taskMetadata[downloadId]?.resumeData` directly — racing the barrier mutations from progress/completion handlers. Dictionary write/write race → corruption or crash; resume data could be silently lost so `resumeDownload` restarted from byte 0.

## Fix
Both pause paths hop the completion body back onto `queue.async(flags: .barrier)` before touching `taskMetadata`.

Stacked on #135. Agreed list RC-2 #9 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)