### PR TITLE
fix: iOS playback speed silently resets to 1x on several paths

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -176,7 +176,7 @@ extension TrackPlayerCore {
     if currentRepeatMode == .track, finishedItem === player?.currentItem {
       NitroPlayerLogger.log("TrackPlayerCore", "🔁 TRACK repeat — seeking to zero and replaying")
       player?.seek(to: .zero)
-      player?.play()
+      player?.rate = Float(currentPlaybackSpeed)
       return  // do not remove temp tracks, do not notify track change (same track looping)
     }
 
@@ -308,7 +308,7 @@ extension TrackPlayerCore {
           lastItem = item
         }
         currentTrackIndex = 0
-        player.play()
+        player.rate = Float(currentPlaybackSpeed)
 
         if let firstTrack = currentTracks.first {
           notifyTrackChange(firstTrack, .repeat)

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -262,7 +262,7 @@ extension TrackPlayerCore {
 
     self.preloadUpcomingTracks(from: index + 1)
 
-    if wasPlaying { player.play() }
+    if wasPlaying { player.rate = Float(currentPlaybackSpeed) }
     return true
   }
 

--- a/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
@@ -138,7 +138,7 @@ extension TrackPlayerCore {
             lastItem = newItem
           }
         }
-        player.play()
+        player.rate = Float(self.currentPlaybackSpeed)
         self.preloadUpcomingTracks(from: self.currentTrackIndex + 1)
       } else {
         // A current AVPlayerItem already exists — preserve it and only rebuild upcoming items.


### PR DESCRIPTION
## Problem
`AVPlayer.play()` sets rate to 1.0 (`defaultRate` is never configured). Four paths bypassed `playInternal`'s `player.rate = Float(currentPlaybackSpeed)`:
- `TrackPlayerQueueBuild.swift` — resume after index jump
- `TrackPlayerListener.swift` — track-repeat loop and playlist-repeat wrap
- `TrackPlayerUrlLoader.swift` — lazy URL resolve

Set speed 2.0 → skip / repeat loops / lazy URL resolves → audio plays at 1.0x while `getPlaybackSpeed()` still reports 2.0.

## Fix
Each site now sets `player.rate = Float(currentPlaybackSpeed)` (the `playInternal` idiom; rate > 0 starts playback at that rate).

Stacked on #137. Agreed list RC-5 #22 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)