### PR TITLE
fix: iOS lazy-load rebuild materializes the entire remaining playlist and force-plays

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerUrlLoader.swift
@@ -131,14 +131,20 @@ extension TrackPlayerCore {
           "🔄 No current item — full queue rebuild from currentTrackIndex \(self.currentTrackIndex)")
         self.removeAllItemsCancellingLoads(player)
         var lastItem: AVPlayerItem? = nil
-        for (offset, track) in self.currentTracks[max(0, self.currentTrackIndex)...].enumerated() {
+        // Window like every other rebuild path — materializing the whole remaining
+        // playlist builds thousands of AVPlayerItems on playerQueue at once.
+        let windowed = self.currentTracks[max(0, self.currentTrackIndex)...]
+          .prefix(1 + Constants.queueWindowSize)
+        for (offset, track) in windowed.enumerated() {
           let isPreload = offset < Constants.gaplessPreloadCount
           if let newItem = self.createGaplessPlayerItem(for: track, isPreload: isPreload) {
             player.insert(newItem, after: lastItem)
             lastItem = newItem
           }
         }
-        player.rate = Float(self.currentPlaybackSpeed)
+        if self.intendedToPlay {
+          player.rate = Float(self.currentPlaybackSpeed)
+        }
         self.preloadUpcomingTracks(from: self.currentTrackIndex + 1)
       } else {
         // A current AVPlayerItem already exists — preserve it and only rebuild upcoming items.


### PR DESCRIPTION
## Problem
The `currentItem == nil` branch of the URL-resolve rebuild inserted `currentTracks[currentTrackIndex...]` **in full** — one AVPlayerItem + AVURLAsset + EQ mix per remaining track. A 2000-track lazy playlist meant 2000 items built serially on playerQueue (multi-second stall, large memory spike), defeating the windowed-queue design used by every other rebuild path. It also started playback unconditionally, even if the user pressed pause while the URL was resolving — and because `intendedToPlay` stayed false, stall recovery was disarmed for that playback.

## Fix
- Window with `.prefix(1 + Constants.queueWindowSize)` like the other rebuild paths (the windowed top-up in `currentItemDidChange` keeps feeding the queue).
- Start playback only when `intendedToPlay` is set, at `currentPlaybackSpeed`.

Stacked on #138. Agreed list RC-5 #23 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)