### PR TITLE
fix: duplicate onSeek emission per seek on iOS

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -187,7 +187,7 @@ extension TrackPlayerCore {
     guard let player = self.player else { return }
     self.isManuallySeeked = true
     let time = CMTime(seconds: position, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-    player.seek(to: time) { [weak self] completed in
+    player.seek(to: time) { _ in
        // HackFix I dont know how to fix this, but it works.
       let rate = Double(player.rate)
       DispatchQueue.main.async {
@@ -197,10 +197,8 @@ extension TrackPlayerCore {
           MPNowPlayingInfoCenter.default().nowPlayingInfo = info
         }
       }
-      if completed {
-        let duration = player.currentItem?.duration.seconds ?? 0.0
-        self?.notifySeek(position, duration)
-      }
+      // No notifySeek here — the same seek fires AVPlayerItemTimeJumped,
+      // whose handler already emits it; calling both doubled every onSeek.
     }
   }
 


### PR DESCRIPTION
## Problem
`seekInternal`'s completion called `notifySeek`, and the same seek also fires `AVPlayerItemTimeJumped`, whose handler calls `notifySeek` again — two JS seek events (plus an extra progress tick) per user seek.

## Fix
Dropped the completion-side call; the TimeJumped notification path (which now also carries the foreign-item guard from #127) covers both system- and user-initiated jumps.

Stacked on #139. Agreed list RC-5 #27 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)