### PR TITLE
fix: iOS skipToNext at the last track kills playback (Android no-ops)

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -238,11 +238,12 @@ extension TrackPlayerCore {
 
     if queuePlayer.items().count > 1 {
       queuePlayer.advanceToNextItem()
+    } else if currentRepeatMode == .playlist, !currentTracks.isEmpty {
+      // Manual skip at the last track wraps, matching natural-end behavior
+      _ = skipToIndexInternal(index: 0)
     } else {
-      queuePlayer.pause()
-      self.intendedToPlay = false
-      self.isRecoveringFromStall = false
-      self.notifyPlaybackStateChange(.stopped, .end)
+      // No next track — no-op and keep playing, matching Android
+      NitroPlayerLogger.log("TrackPlayerCore", "⏭️ skipToNext at last track — nothing to advance to")
     }
 
     checkUpcomingTracksForUrls(lookahead: lookaheadCount)


### PR DESCRIPTION
## Problem
With no upcoming track, iOS paused, cleared `intendedToPlay`, and emitted `.stopped/.end` — killing the currently playing track. Android's `skipToNextOnQueue` no-ops and keeps playing. And with repeat `.playlist`, a manual skip at the last track stopped instead of wrapping (only the natural item end wrapped).

## Fix
- Repeat `.playlist`: manual skip at the last track wraps via `skipToIndexInternal(index: 0)`.
- Otherwise: no-op, keep playing — platform behavior now matches.

Stacked on #140. Agreed list RC-5 #26 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)