### PR TITLE
fix: iOS module init activates the audio session immediately

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -149,11 +149,23 @@ class TrackPlayerCore: NSObject {
 
   internal func setupAudioSession() {
     do {
-      let audioSession = AVAudioSession.sharedInstance()
-      try audioSession.setCategory(.playback, mode: .default, options: [])
-      try audioSession.setActive(true)
+      // Category only — setActive(true) is deferred to first play so merely
+      // loading the module doesn't silence other apps' audio.
+      try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
     } catch {
       NitroPlayerLogger.log("TrackPlayerCore", "❌ Failed to setup audio session - \(error)")
+    }
+  }
+
+  private var audioSessionActivated = false
+
+  internal func activateAudioSessionIfNeeded() {
+    guard !audioSessionActivated else { return }
+    do {
+      try AVAudioSession.sharedInstance().setActive(true)
+      audioSessionActivated = true
+    } catch {
+      NitroPlayerLogger.log("TrackPlayerCore", "❌ Failed to activate audio session - \(error)")
     }
   }
 

--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -150,6 +150,7 @@ extension TrackPlayerCore {
 
   func playInternal() {
     NitroPlayerLogger.log("TrackPlayerCore", "▶️ play() called")
+    activateAudioSessionIfNeeded()
     self.intendedToPlay = true
     // An explicit play() is the ground truth for intent — clear any stale
     // interruption flag so a missed AVAudioSession `.ended` can't permanently


### PR DESCRIPTION
## Problem
`TrackPlayerCore.init` called `setCategory(.playback)` + `setActive(true)` synchronously on whatever thread first touched the singleton (typically the JS thread at module load). Merely importing the module silenced any other app's audio (Spotify, podcasts) before the user played anything, and `setActive(true)` can block the JS thread for tens of ms at startup.

## Fix
Init keeps only `setCategory` (cheap, non-disruptive). `setActive(true)` moved to a once-guarded `activateAudioSessionIfNeeded()` called from `playInternal` — other apps keep playing until the user actually starts playback. The interruption-recovery path (`TrackPlayerRecovery`) still re-activates on its own.

Stacked on #141. Agreed list RC-5 #28 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)