### PR TITLE
fix: pre-Android-12 A2DP selection routes music through narrowband SCO

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridAudioDevices.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridAudioDevices.kt
@@ -67,9 +67,17 @@ class HybridAudioDevices : HybridAudioDevicesSpec() {
                     audioManager.setCommunicationDevice(device)
                 } else {
                     when (device.type) {
-                        AudioDeviceInfo.TYPE_BLUETOOTH_SCO, AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> {
+                        AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> {
                             audioManager.startBluetoothSco()
                             audioManager.isBluetoothScoOn = true
+                        }
+
+                        // A2DP is the default media route — routing it through SCO
+                        // would drop music to narrowband call quality
+                        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> {
+                            audioManager.stopBluetoothSco()
+                            audioManager.isBluetoothScoOn = false
+                            audioManager.isSpeakerphoneOn = false
                         }
 
                         AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> {


### PR DESCRIPTION
## Problem
On API < 31, selecting a `TYPE_BLUETOOTH_A2DP` device called `startBluetoothSco()` + `isBluetoothScoOn = true`. SCO is narrowband call audio — music dropped to phone-call quality. A2DP is the default media route and needs no SCO at all.

## Fix
A2DP selection now clears SCO/speakerphone flags (audio flows over A2DP by default); `startBluetoothSco` is reserved for actual `TYPE_BLUETOOTH_SCO` devices.

Stacked on #142. Agreed list RC-5 #29 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)