### PR TITLE
fix: Android Auto connection query leaks cursor on early-return branches

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/connection/AndroidAutoConnectionDetector.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/connection/AndroidAutoConnectionDetector.kt
@@ -144,29 +144,29 @@ class AndroidAutoConnectionDetector(
                 return
             }
 
-            val carConnectionTypeColumn = response.getColumnIndex(CAR_CONNECTION_STATE)
-            if (carConnectionTypeColumn < 0) {
-                NitroPlayerLogger.log("AndroidAutoConnection", "⚠️ Connection type column missing, treating as disconnected")
-                notifyCarDisconnected()
-                return
+            response.use { cursor ->
+                val carConnectionTypeColumn = cursor.getColumnIndex(CAR_CONNECTION_STATE)
+                if (carConnectionTypeColumn < 0) {
+                    NitroPlayerLogger.log("AndroidAutoConnection", "⚠️ Connection type column missing, treating as disconnected")
+                    notifyCarDisconnected()
+                    return
+                }
+
+                if (!cursor.moveToNext()) {
+                    NitroPlayerLogger.log("AndroidAutoConnection", "⚠️ Empty response, treating as disconnected")
+                    notifyCarDisconnected()
+                    return
+                }
+
+                val connectionState = cursor.getInt(carConnectionTypeColumn)
+                NitroPlayerLogger.log("AndroidAutoConnection", "📊 Connection state queried: $connectionState")
+
+                if (connectionState == CONNECTION_TYPE_NOT_CONNECTED) {
+                    notifyCarDisconnected()
+                } else {
+                    notifyCarConnected(connectionState)
+                }
             }
-
-            if (!response.moveToNext()) {
-                NitroPlayerLogger.log("AndroidAutoConnection", "⚠️ Empty response, treating as disconnected")
-                notifyCarDisconnected()
-                return
-            }
-
-            val connectionState = response.getInt(carConnectionTypeColumn)
-            NitroPlayerLogger.log("AndroidAutoConnection", "📊 Connection state queried: $connectionState")
-
-            if (connectionState == CONNECTION_TYPE_NOT_CONNECTED) {
-                notifyCarDisconnected()
-            } else {
-                notifyCarConnected(connectionState)
-            }
-
-            response.close()
         }
     }
 }


### PR DESCRIPTION
## Problem
`onQueryComplete` closed the cursor only on the success path. The missing-column and empty-result branches returned a non-null cursor without `close()` — repeated connection broadcasts leak CursorWindow/file-descriptor resources.

## Fix
Non-null cursor wrapped in `response.use { }` so every exit path closes it. (The null-response branch has no cursor to close.)

Stacked on #143. Agreed list RC-5 #30 / Codex finding D (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)