### PR TITLE
fix: per-URL auth headers map grows unboundedly

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
@@ -12,7 +12,7 @@ import androidx.media3.datasource.ResolvingDataSource
  * Headers are registered per effective URL via [setHeadersForUrl] during MediaItem
  * construction and applied through a [ResolvingDataSource] just before each request opens.
  *
- * The registry is a [ConcurrentHashMap] because it is written on the player thread but
+ * The registry is a synchronized LRU map because it is written on the player thread but
  * read on ExoPlayer's loader threads.
  */
 @UnstableApi

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/media/AuthAwareHttpDataSourceFactory.kt
@@ -4,7 +4,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * HTTP [DataSource.Factory] that injects per-URL request headers (e.g. `Authorization`)
@@ -34,7 +33,17 @@ class AuthAwareHttpDataSourceFactory : DataSource.Factory {
     override fun createDataSource(): DataSource = factory.createDataSource()
 
     companion object {
-        private val headersMap = ConcurrentHashMap<String, Map<String, String>>()
+        // LRU-bounded: rotating signed URLs would otherwise add an entry per
+        // playback for the process lifetime (destroy() has no callers today)
+        private const val MAX_HEADER_ENTRIES = 500
+
+        private val headersMap: MutableMap<String, Map<String, String>> =
+            java.util.Collections.synchronizedMap(
+                object : LinkedHashMap<String, Map<String, String>>(16, 0.75f, true) {
+                    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Map<String, String>>) =
+                        size > MAX_HEADER_ENTRIES
+                },
+            )
 
         fun setHeadersForUrl(url: String, headers: Map<String, String>) {
             headersMap[url] = headers


### PR DESCRIPTION
## Problem
Headers are keyed per exact effective URL and only cleared in `destroy()` — which nothing calls. Apps with rotating signed URLs (a new token per play) accumulate an entry per playback for the process lifetime.

## Fix
Synchronized access-order `LinkedHashMap` with `removeEldestEntry` capped at 500 entries — least-recently-used headers age out.

Stacked on #144. Agreed list RC-1 #3 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)