### PR TITLE
fix: Android progress runnable wakes the main looper every second forever

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -124,15 +124,21 @@ class TrackPlayerCore private constructor(
     internal val progressUpdateRunnable =
         object : Runnable {
             override fun run() {
-                if (::exo.isInitialized && exo.isPlaying) {
-                    val pos = exo.currentPosition / 1000.0
-                    val dur = if (exo.duration > 0) exo.duration / 1000.0 else 0.0
-                    notifyPlaybackProgress(pos, dur, if (isManuallySeeked) true else null)
-                    isManuallySeeked = false
-                }
+                // Stop ticking while paused/idle — onIsPlayingChanged restarts it,
+                // so the main looper isn't woken every second for the process lifetime
+                if (!::exo.isInitialized || !exo.isPlaying) return
+                val pos = exo.currentPosition / 1000.0
+                val dur = if (exo.duration > 0) exo.duration / 1000.0 else 0.0
+                notifyPlaybackProgress(pos, dur, if (isManuallySeeked) true else null)
+                isManuallySeeked = false
                 playerHandler.postDelayed(this, PROGRESS_INTERVAL_MS)
             }
         }
+
+    internal fun startProgressTicks() {
+        playerHandler.removeCallbacks(progressUpdateRunnable)
+        playerHandler.postDelayed(progressUpdateRunnable, PROGRESS_INTERVAL_MS)
+    }
 
     internal val updateCurrentPlaylistRunnable =
         Runnable {

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
@@ -149,6 +149,7 @@ internal class TrackPlayerEventListener(
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
+        if (isPlaying) core.startProgressTicks()
         core.emitStateChange()
     }
 


### PR DESCRIPTION
## Problem
The progress tick correctly skipped the JS callback when not playing, but re-posted itself unconditionally — waking the main looper once per second for the process lifetime from first service bind, playing or not. Battery/CPU drain of the same class as the fixed #118 background sawtooth.

## Fix
The runnable stops re-posting when not playing; `onIsPlayingChanged(true)` restarts it via `startProgressTicks()` (which de-dupes with `removeCallbacks` first). Zero timer wakeups while paused/idle.

Stacked on #145. Agreed list item 37 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)