### PR TITLE
fix: redundant clearMediaItems causes an extra null-item transition per index jump

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -85,7 +85,6 @@ internal fun TrackPlayerCore.rebuildQueueAndPlayFromIndex(index: Int) {
         }
 
     currentTrackIndex = index
-    exo.clearMediaItems()
     exo.setMediaItems(mediaItems, true)
     exo.prepare()
 }


### PR DESCRIPTION
## Problem
`rebuildQueueAndPlayFromIndex` cleared then set; `setMediaItems` already replaces the timeline atomically, so the clear only produced an extra null-item `onMediaItemTransition(PLAYLIST_CHANGED)` and timeline callback per jump.

## Fix
Deleted the `clearMediaItems()` line.

Stacked on #146. Agreed list item 38 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)