### PR TITLE
fix: download progress event flood (iOS) and per-record stat() in getQueueStatus (Android)

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadDatabase.kt
@@ -109,6 +109,12 @@ class DownloadDatabase private constructor(
         synchronized(this) { existenceCache.clear() }
     }
 
+    /** Count via the memoized existence cache — no per-record stat() on the caller's thread. */
+    fun countDownloadedTracks(): Int =
+        synchronized(this) {
+            downloadedTracks.count { (trackId, record) -> cachedFileExists(trackId, record.localPath) }
+        }
+
     fun isPlaylistDownloaded(playlistId: String): Boolean {
         synchronized(this) {
             val trackIds = playlistTracks[playlistId] ?: return false

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -258,7 +258,7 @@ class DownloadManagerCore private constructor(
             downloadedBytes += m.bytesDownloaded
         }
 
-        val completedCount = database.getAllDownloadedTracks().size
+        val completedCount = database.countDownloadedTracks()
 
         return DownloadQueueStatus(
             pendingCount = pendingCount.toDouble(),

--- a/react-native-nitro-player/ios/download/DownloadManagerCore.swift
+++ b/react-native-nitro-player/ios/download/DownloadManagerCore.swift
@@ -911,6 +911,14 @@ extension DownloadManagerCore: URLSessionDownloadDelegate {
       self.taskMetadata[downloadId]?.totalBytes =
         totalBytesExpectedToWrite > 0 ? Double(totalBytesExpectedToWrite) : nil
 
+      // ~4 Hz per download — didWriteData fires many times per second per task
+      // and every emission is a main-queue hop plus a JS event
+      let now = Date().timeIntervalSince1970
+      if let last = self.taskMetadata[downloadId]?.lastProgressEmitAt, now - last < 0.25 {
+        return
+      }
+      self.taskMetadata[downloadId]?.lastProgressEmitAt = now
+
       let progress = DownloadProgress(
         trackId: trackId,
         downloadId: downloadId,
@@ -1014,6 +1022,7 @@ private struct DownloadTaskMetadata {
   var bytesDownloaded: Double = 0
   var totalBytes: Double?
   var error: DownloadError?
+  var lastProgressEmitAt: TimeInterval = 0
 
   func toDownloadTask() -> DownloadTask {
     let progress = DownloadProgress(


### PR DESCRIPTION
## Problems (agreed list RC-4 #20)
- **iOS**: every `didWriteData` callback (many per second per task, ×3 concurrent tasks) did a barrier hop, built a `DownloadProgress`, and dispatched main → JS.
- **Android**: `getQueueStatus()` — a synchronous JS-thread call apps poll during active downloads — went through `getAllDownloadedTracks()`, which does a raw `File.exists()` per record, bypassing the memoized `existenceCache`.

## Fix
- iOS: per-download `lastProgressEmitAt` in `DownloadTaskMetadata`; progress emitted at most every 250 ms (~4 Hz). Byte counters still update on every callback, so completion/state math is unaffected.
- Android: new `DownloadDatabase.countDownloadedTracks()` counts via the memoized cache; `getQueueStatus` uses it.

Stacked on #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)