### PR TITLE
fix: Android pause/resume restarts downloads from byte 0

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -220,6 +220,11 @@ class DownloadManagerCore private constructor(
             metadata.state = DownloadState.CANCELLED
             notifyStateChange(downloadId, metadata.trackId, DownloadState.CANCELLED, null)
             activeTasks.remove(downloadId)
+            // Drop the partial file (pause keeps it for Range resume), but never
+            // a previously completed download's file
+            if (!database.isTrackDownloaded(metadata.trackId)) {
+                fileManager.getLocalPath(metadata.trackId)?.let { fileManager.deleteFile(it) }
+            }
         }
         releaseDownloadSlot(downloadId)
     }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
@@ -169,16 +169,28 @@ class DownloadWorker(
             var destinationFile: File? = null
 
             try {
+                val partialPath = fileManager.getLocalPath(trackId)
+                val existingBytes = partialPath?.let { File(it).length() } ?: 0L
+
                 val url = URL(urlString)
                 connection = url.openConnection() as HttpURLConnection
                 connection.connectTimeout = 30000
                 connection.readTimeout = 30000
+                if (existingBytes > 0) {
+                    connection.setRequestProperty("Range", "bytes=$existingBytes-")
+                }
                 connection.connect()
 
                 val responseCode = connection.responseCode
-                if (responseCode != HttpURLConnection.HTTP_OK) {
+                if (responseCode == 416) {
+                    // Partial file is at or past the server's length — start clean next attempt
+                    partialPath?.let { File(it).delete() }
+                    throw Exception("Server returned HTTP 416 for resume, restarting download")
+                }
+                if (responseCode != HttpURLConnection.HTTP_OK && responseCode != HttpURLConnection.HTTP_PARTIAL) {
                     throw Exception("Server returned HTTP $responseCode")
                 }
+                val resuming = responseCode == HttpURLConnection.HTTP_PARTIAL && existingBytes > 0 && partialPath != null
                 // Determine extension
                 var extension = MimeTypeMap.getFileExtensionFromUrl(urlString)
 
@@ -205,14 +217,22 @@ class DownloadWorker(
 
                 val finalExtension = if (extension.isNullOrEmpty()) "mp3" else extension
 
-                // Create destination file
-                destinationFile = fileManager.createDownloadFile(trackId, storageLocation, finalExtension)
+                // Create destination file — appending to the partial file when the
+                // server honored the Range request, truncating otherwise
+                destinationFile =
+                    if (resuming) {
+                        File(partialPath!!)
+                    } else {
+                        fileManager.createDownloadFile(trackId, storageLocation, finalExtension)
+                    }
 
                 inputStream = BufferedInputStream(connection.inputStream)
-                outputStream = FileOutputStream(destinationFile)
+                outputStream = FileOutputStream(destinationFile, resuming)
 
-                val totalBytes = connection.contentLengthLong
-                var bytesDownloaded: Long = 0
+                val startOffset = if (resuming) existingBytes else 0L
+                val totalBytes =
+                    if (connection.contentLengthLong > 0) connection.contentLengthLong + startOffset else -1L
+                var bytesDownloaded: Long = startOffset
 
                 val buffer = ByteArray(BUFFER_SIZE)
                 var bytesRead: Int
@@ -242,7 +262,8 @@ class DownloadWorker(
 
                 destinationFile.absolutePath
             } catch (e: CancellationException) {
-                destinationFile?.delete()
+                // Keep the partial file — pause resumes from this offset via Range;
+                // an explicit cancel deletes it in DownloadManagerCore.cancelDownload
                 throw e
             } catch (e: Exception) {
                 throw e


### PR DESCRIPTION
## Problem
`pauseDownload` cancelled the work; `resumeDownload` enqueued a fresh request with no `Range` header and a truncating `FileOutputStream` — a 90%-complete download restarted at zero.

## Fix
- Worker checks for an existing partial file (`fileManager.getLocalPath`) and sends `Range: bytes=N-`; on HTTP 206 it appends to the partial file, starts byte accounting at the offset, and reports correct totals. On plain 200 (no server range support) it truncates and starts over; on 416 it deletes the stale partial and retries clean.
- Pause now keeps the partial file (the cancellation path from #130 no longer deletes it); an explicit `cancelDownload` deletes the partial — guarded so a previously completed download's file is never removed.

Stacked on #149. Agreed list RC-3 #15 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)