### PR TITLE
fix: useAudioDevices re-renders every consumer every 2 seconds forever

### DIFF
--- a/react-native-nitro-player/src/hooks/useAudioDevices.ts
+++ b/react-native-nitro-player/src/hooks/useAudioDevices.ts
@@ -1,8 +1,13 @@
 import { useEffect, useState } from 'react'
-import { Platform } from 'react-native'
-import { NitroModules } from 'react-native-nitro-modules'
-import type { AudioDevices as AudioDevicesType } from '../specs/AudioDevices.nitro'
+import { AudioDevices } from '../index'
 import type { TAudioDevice } from '../specs/AudioDevices.nitro'
+
+function devicesEqual(a: TAudioDevice[], b: TAudioDevice[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every(
+    (d, i) => d.id === b[i]!.id && d.isActive === b[i]!.isActive
+  )
+}
 
 /**
  * Hook to get audio devices (Android only)
@@ -30,34 +35,28 @@ export function useAudioDevices() {
   const [devices, setDevices] = useState<TAudioDevice[]>([])
 
   useEffect(() => {
-    if (Platform.OS !== 'android') {
+    if (!AudioDevices) {
       return undefined
     }
 
-    try {
-      const AudioDevices =
-        NitroModules.createHybridObject<AudioDevicesType>('AudioDevices')
-
-      // Get initial devices
-      const updateDevices = () => {
-        try {
-          const currentDevices = AudioDevices.getAudioDevices()
-          setDevices(currentDevices)
-        } catch (error) {
-          console.error('Error getting audio devices:', error)
-        }
+    const updateDevices = () => {
+      try {
+        const currentDevices = AudioDevices!.getAudioDevices()
+        // Bail when nothing changed — the bridge returns a fresh array identity
+        // every tick, which would otherwise re-render every consumer at 0.5Hz
+        setDevices((prev) =>
+          devicesEqual(prev, currentDevices) ? prev : currentDevices
+        )
+      } catch (error) {
+        console.error('Error getting audio devices:', error)
       }
-
-      updateDevices()
-
-      // Poll for changes every 2 seconds
-      const interval = setInterval(updateDevices, 2000)
-
-      return () => clearInterval(interval)
-    } catch (error) {
-      console.error('Error setting up audio devices polling:', error)
-      return undefined
     }
+
+    updateDevices()
+
+    const interval = setInterval(updateDevices, 2000)
+
+    return () => clearInterval(interval)
   }, [])
 
   return { devices }


### PR DESCRIPTION
## Problem
The 2 s poll called `getAudioDevices()` (fresh array identity from the bridge each tick) and `setDevices` with no equality check — every consumer re-rendered at 0.5 Hz for its whole lifetime. Battery/CPU drain of the same class as the fixed background-sawtooth issue (#118). The hook also created a **new** `AudioDevices` hybrid object per mount instead of reusing the shared export.

## Fix
- Functional `setDevices` bails to `prev` when id/isActive sequences are unchanged — no re-render on quiet ticks.
- Reuses the `AudioDevices` export from `src/index.ts` (which is already `null` off-Android, replacing the Platform check).

Stacked on #151. Agreed list RC-6 #32 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)