### PR TITLE
fix: useActualQueue fetches the queue twice per skip event burst

### DIFF
--- a/react-native-nitro-player/src/hooks/useActualQueue.ts
+++ b/react-native-nitro-player/src/hooks/useActualQueue.ts
@@ -73,6 +73,18 @@ export function useActualQueue(): UseActualQueueResult {
     }
   }, [])
 
+  // Skips involving temp tracks fire track-change and temporary-queue-change
+  // together; the gate collapses the burst into one getActualQueue() fetch
+  const fetchScheduled = useRef(false)
+  const scheduleUpdate = useCallback(() => {
+    if (fetchScheduled.current) return
+    fetchScheduled.current = true
+    queueMicrotask(() => {
+      fetchScheduled.current = false
+      updateQueue()
+    })
+  }, [updateQueue])
+
   const refreshQueue = useCallback(() => {
     if (!isMounted.current) return
     setIsLoading(true)
@@ -97,25 +109,25 @@ export function useActualQueue(): UseActualQueueResult {
   // track changes and temporary-queue edits do.
   useEffect(() => {
     return callbackManager.subscribeToTrackChange(() => {
-      updateQueue()
+      scheduleUpdate()
     })
-  }, [updateQueue])
+  }, [scheduleUpdate])
 
   // Update queue when playNext / upNext change (native pushes the new lists).
   useEffect(() => {
     return callbackManager.subscribeToTemporaryQueueChange(() => {
-      updateQueue()
+      scheduleUpdate()
     })
-  }, [updateQueue])
+  }, [scheduleUpdate])
 
   // Update queue when the playlist itself is edited (track added / removed / reordered).
   // Without this, a playlist mutation while paused would leave the queue stale until the
   // next track change — playback-state changes used to paper over it.
   useEffect(() => {
     return callbackManager.subscribeToPlaylistsChanged(() => {
-      updateQueue()
+      scheduleUpdate()
     })
-  }, [updateQueue])
+  }, [scheduleUpdate])
 
   return { queue, refreshQueue, isLoading }
 }


### PR DESCRIPTION
## Problem
Track-change and temporary-queue-change events fire together on skips involving temp tracks; each started its own `getActualQueue()` — a redundant full-queue bridge crossing per burst. (Ordering is safe — both platforms resolve these promises FIFO through the serial command queue, as established in review — so this is purely wasted work, not a race.)

## Fix
A microtask gate collapses same-tick event bursts into one fetch. Manual `refreshQueue()` still fetches immediately.

Stacked on #153. Agreed list RC-6 #34 (Fable/Codex review, per Codex correction 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)