### PR TITLE
fix: concurrent download actions clobber loading flags; usagePercentage NaN

### DIFF
--- a/react-native-nitro-player/src/hooks/useDownloadActions.ts
+++ b/react-native-nitro-player/src/hooks/useDownloadActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { DownloadManager } from '../index'
 import type { DownloadConfig, PlaybackSource } from '../types/DownloadTypes'
 import type { TrackItem } from '../types/PlayerQueue'
@@ -45,10 +45,34 @@ export function useDownloadActions(): UseDownloadActionsResult {
   const [isDownloading, setIsDownloading] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  // Pending counts: overlapping calls otherwise clear the flag while a
+  // second request is still in flight
+  const downloadingCount = useRef(0)
+  const deletingCount = useRef(0)
+
+  const beginDownloading = useCallback(() => {
+    downloadingCount.current += 1
+    setIsDownloading(true)
+  }, [])
+
+  const endDownloading = useCallback(() => {
+    downloadingCount.current = Math.max(0, downloadingCount.current - 1)
+    if (downloadingCount.current === 0) setIsDownloading(false)
+  }, [])
+
+  const beginDeleting = useCallback(() => {
+    deletingCount.current += 1
+    setIsDeleting(true)
+  }, [])
+
+  const endDeleting = useCallback(() => {
+    deletingCount.current = Math.max(0, deletingCount.current - 1)
+    if (deletingCount.current === 0) setIsDeleting(false)
+  }, [])
 
   const downloadTrack = useCallback(
     async (track: TrackItem, playlistId?: string) => {
-      setIsDownloading(true)
+      beginDownloading()
       setError(null)
       try {
         const downloadId = await DownloadManager.downloadTrack(
@@ -60,7 +84,7 @@ export function useDownloadActions(): UseDownloadActionsResult {
         setError(e as Error)
         throw e
       } finally {
-        setIsDownloading(false)
+        endDownloading()
       }
     },
     []
@@ -68,7 +92,7 @@ export function useDownloadActions(): UseDownloadActionsResult {
 
   const downloadPlaylist = useCallback(
     async (playlistId: string, tracks: TrackItem[]) => {
-      setIsDownloading(true)
+      beginDownloading()
       setError(null)
       try {
         const downloadIds = await DownloadManager.downloadPlaylist(
@@ -80,7 +104,7 @@ export function useDownloadActions(): UseDownloadActionsResult {
         setError(e as Error)
         throw e
       } finally {
-        setIsDownloading(false)
+        endDownloading()
       }
     },
     []
@@ -115,29 +139,29 @@ export function useDownloadActions(): UseDownloadActionsResult {
   }, [])
 
   const deleteTrack = useCallback(async (trackId: string) => {
-    setIsDeleting(true)
+    beginDeleting()
     try {
       await DownloadManager.deleteDownloadedTrack(trackId)
     } finally {
-      setIsDeleting(false)
+      endDeleting()
     }
   }, [])
 
   const deletePlaylist = useCallback(async (playlistId: string) => {
-    setIsDeleting(true)
+    beginDeleting()
     try {
       await DownloadManager.deleteDownloadedPlaylist(playlistId)
     } finally {
-      setIsDeleting(false)
+      endDeleting()
     }
   }, [])
 
   const deleteAll = useCallback(async () => {
-    setIsDeleting(true)
+    beginDeleting()
     try {
       await DownloadManager.deleteAllDownloads()
     } finally {
-      setIsDeleting(false)
+      endDeleting()
     }
   }, [])
 

--- a/react-native-nitro-player/src/hooks/useDownloadStorage.ts
+++ b/react-native-nitro-player/src/hooks/useDownloadStorage.ts
@@ -69,9 +69,10 @@ export function useDownloadStorage(): UseDownloadStorageResult {
     ? formatBytes(storageInfo.availableSpace)
     : '0 B'
 
-  const usagePercentage = storageInfo
-    ? (storageInfo.totalDownloadedSize / storageInfo.totalSpace) * 100
-    : 0
+  const usagePercentage =
+    storageInfo && storageInfo.totalSpace > 0
+      ? (storageInfo.totalDownloadedSize / storageInfo.totalSpace) * 100
+      : 0
 
   return {
     storageInfo,


### PR DESCRIPTION
## Problems (agreed list RC-6 #35)
- `useDownloadActions`: boolean flags with `finally { set(false) }` — the first of two overlapping `downloadTrack`/`deleteTrack` calls cleared the flag while the second was still in flight (spinner disappears, button re-enables early).
- `useDownloadStorage`: `usagePercentage` divided by `totalSpace` with no zero guard → `NaN` when native reports 0 before storage resolves.

## Fix
- Pending-count refs: the flag drops only when the last in-flight call finishes.
- Zero guard on `totalSpace`.

Stacked on #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)