### PR TITLE
fix: TrackPlayerCore singleton pins the ReactApplicationContext forever

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerCore.kt
@@ -12,7 +12,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import com.facebook.react.bridge.ReactApplicationContext
+import com.margelo.nitro.NitroModules
 import com.margelo.nitro.nitroplayer.Reason
 import com.margelo.nitro.nitroplayer.RepeatMode
 import com.margelo.nitro.nitroplayer.TimedMetadata
@@ -220,9 +220,11 @@ class TrackPlayerCore private constructor(
         @Suppress("ktlint:standard:property-naming")
         private var INSTANCE: TrackPlayerCore? = null
 
+        // applicationContext: the process-lifetime singleton must not pin the
+        // ReactApplicationContext (and its whole JS runtime) across reloads
         fun getInstance(context: Context): TrackPlayerCore =
             INSTANCE ?: synchronized(this) {
-                INSTANCE ?: TrackPlayerCore(context).also { INSTANCE = it }
+                INSTANCE ?: TrackPlayerCore(context.applicationContext).also { INSTANCE = it }
             }
     }
 
@@ -411,7 +413,7 @@ class TrackPlayerCore private constructor(
         val id = onNotificationLaunchListeners.add(cb)
         handler.post {
             registerNotificationLaunchDetection()
-            checkNotificationLaunch((context as? ReactApplicationContext)?.currentActivity)
+            checkNotificationLaunch(NitroModules.applicationContext?.currentActivity)
         }
         return id
     }


### PR DESCRIPTION
## Problem
`getInstance(context)` stored the passed context directly (Nitro passes the `ReactApplicationContext`) — unlike `DownloadManagerCore`/`PlaylistManager`, which store `context.applicationContext`. On React-instance recreation (dev reload, bridgeless host restart) the process-lifetime singleton retained the old ReactApplicationContext and the entire old JS runtime; `checkNotificationLaunch` also queried the stale context, breaking notification-launch detection after reload.

## Fix
- Singleton stores `context.applicationContext`.
- Notification-launch detection resolves the **live** activity on demand via `NitroModules.applicationContext?.currentActivity` (per review consensus: appContext for process-lifetime use, live lookup where the current React context is required).

Stacked on #155. Agreed list item 36 (Fable/Codex review, incl. Codex correction 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)