### PR TITLE
fix: stale async preloads repopulate the iOS asset cache after a queue switch

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -65,6 +65,9 @@ class TrackPlayerCore: NSObject {
 
   // Gapless playback
   internal var preloadedAssets: [String: AVURLAsset] = [:]
+  // playerQueue-owned; bumped on every teardown so in-flight async preloads
+  // can't republish a stale asset into the cache after a queue switch
+  internal var preloadGeneration: Int = 0
   internal let preloadQueue = DispatchQueue(label: "com.nitroplayer.preload", qos: .utility)
   internal var didRequestUrlsForCurrentItem = false
 
@@ -273,6 +276,7 @@ class TrackPlayerCore: NSObject {
       self.pathMonitor = nil
       for asset in self.preloadedAssets.values { asset.cancelLoading() }
       self.preloadedAssets.removeAll()
+      self.preloadGeneration += 1
       self.failedItemRetryCounts.removeAll()
       self.redirectResolver.clear()
     }

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -85,6 +85,7 @@ extension TrackPlayerCore {
     // Clear old preloaded assets when loading new queue
     for asset in preloadedAssets.values { asset.cancelLoading() }
     preloadedAssets.removeAll()
+    preloadGeneration += 1
 
     guard let existingPlayer = self.player else {
       NitroPlayerLogger.log("TrackPlayerCore", "❌ No player available")
@@ -569,6 +570,7 @@ extension TrackPlayerCore {
     // Swift Array/Dictionary are not safe for concurrent access.
     let queuedTrackIds = Set(player?.items().compactMap { $0.trackId } ?? [])
     let alreadyPreloaded = Set(preloadedAssets.keys)
+    let generation = preloadGeneration
     let endIndex = min(startIndex + Constants.gaplessPreloadCount, currentTracks.count)
     guard startIndex >= 0, startIndex < endIndex else { return }
     let candidates = Array(currentTracks[startIndex..<endIndex])
@@ -607,7 +609,17 @@ extension TrackPlayerCore {
 
           if allKeysLoaded {
             self?.playerQueue.async {
-              self?.preloadedAssets[track.id] = asset
+              guard let self else { return }
+              // Stale completion: the queue was torn down (or this track left it)
+              // while the asset was still loading — publishing would hand a dead
+              // or wrong-URL asset to createGaplessPlayerItem
+              guard self.preloadGeneration == generation,
+                self.currentTracks.contains(where: { $0.id == track.id })
+              else {
+                asset.cancelLoading()
+                return
+              }
+              self.preloadedAssets[track.id] = asset
               NitroPlayerLogger.log("TrackPlayerCore", "🎯 Preloaded asset for upcoming track: \(track.title)")
             }
           }

--- a/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerTempQueue.swift
@@ -55,6 +55,7 @@ extension TrackPlayerCore {
       self.currentTracks = playlist.tracks
       for asset in self.preloadedAssets.values { asset.cancelLoading() }
       self.preloadedAssets.removeAll()
+      self.preloadGeneration += 1
       _ = self.rebuildQueueFromPlaylistIndex(index: targetIndex)
     }
     self.emitStateChange()


### PR DESCRIPTION
## Problem
Queue replacement cancelled only assets **already stored** in `preloadedAssets`. Assets still inside `loadValuesAsynchronously` were untracked; their completions could publish an old playlist/old URL into the cache after it was cleared. A later track with the same ID could then reuse the stale asset (wrong effective URL), and otherwise the old asset stayed retained.

## Fix
playerQueue-owned `preloadGeneration`, bumped at every cache-clearing teardown (`updatePlayerQueue`, temp-queue rebuild, `destroy`). Completions hop to playerQueue and publish only when the generation still matches **and** the track is still in `currentTracks`; otherwise the asset is cancelled and dropped. `cancelLoading` runs on playerQueue, never the main thread (per the AVURLAsset-dealloc lesson documented in `cancelLoading(of:)`).

Stacked on #156. Agreed list RC-2 #11 / Codex finding E (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)