### PR TITLE
fix: Cast disconnect wipes playNext/upNext and seeks the wrong track

### DIFF
--- a/react-native-nitro-player/ios/core/TrackPlayerCast.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCast.swift
@@ -67,13 +67,44 @@ extension TrackPlayerCore {
       guard let self else { return }
       guard self.isCasting else { return }
       let resumePosition = self.castManager?.lastKnownRemotePosition ?? 0
+      let remoteTrackId = self.castManager?.currentRemoteTrackId
       self.isCasting = false
 
       let index = self.currentTrackIndex
       guard index >= 0 && index < self.currentTracks.count else { return }
 
+      // rebuildQueueFromPlaylistIndex wipes the temp lists — preserve them
+      let savedPlayNext = self.playNextStack
+      let savedUpNext = self.upNextQueue
+
       _ = self.rebuildQueueFromPlaylistIndex(index: index)
-      if resumePosition.isFinite && resumePosition > 0 {
+
+      if !savedPlayNext.isEmpty || !savedUpNext.isEmpty {
+        self.playNextStack = savedPlayNext
+        self.upNextQueue = savedUpNext
+        self.rebuildAVQueueFromCurrentPosition()
+        self.notifyTemporaryQueueChange()
+      }
+
+      // If the receiver was playing the head temp track, make it current again
+      // (mirrors skipToNext: remove from its list before it becomes current)
+      if let target = remoteTrackId, target != self.player?.currentItem?.trackId {
+        if self.playNextStack.first?.id == target {
+          self.playNextStack.removeFirst()
+          self.player?.advanceToNextItem()
+          self.currentTemporaryType = .playNext
+          self.notifyTemporaryQueueChange()
+        } else if self.playNextStack.isEmpty, self.upNextQueue.first?.id == target {
+          self.upNextQueue.removeFirst()
+          self.player?.advanceToNextItem()
+          self.currentTemporaryType = .upNext
+          self.notifyTemporaryQueueChange()
+        }
+      }
+
+      // Only seek when the local current track is the one that was playing remotely
+      if resumePosition.isFinite && resumePosition > 0,
+        remoteTrackId != nil, self.player?.currentItem?.trackId == remoteTrackId {
         let time = CMTime(seconds: resumePosition, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
         self.player?.seek(to: time)
       }


### PR DESCRIPTION
## Problem
`handleCastDisconnected` rebuilt via `rebuildQueueFromPlaylistIndex`, which unconditionally clears `playNextStack`/`upNextQueue`, then applied `lastKnownRemotePosition` to `currentTracks[currentTrackIndex]` even when a temp (playNext/upNext) track was playing on the receiver. playNext track B at 1:30 on the receiver, session ends → locally the **original** track A started, seeked to 1:30, with the whole temp queue wiped.

## Fix
- Temp lists are snapshotted before the rebuild and restored after; `rebuildAVQueueFromCurrentPosition` re-inserts them as upcoming items.
- When the receiver was playing the head temp track, it becomes the local current again (removed from its list first, matching the skipToNext invariant).
- The remote position is applied only when the local current track ID equals `castManager.currentRemoteTrackId` — never onto a different track.

Deliberate ceiling: if the remote temp track is no longer at the head of a temp list, playback falls back to the original track at the return index (position skipped) with the pending temps intact.

Stacked on #157. Agreed list RC-5 #24 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)