### PR TITLE
fix: PlaylistManager cross-thread races on both platforms

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
@@ -28,7 +28,7 @@ class PlaylistManager private constructor(
 ) {
     private val playlists = ConcurrentHashMap<String, Playlist>()
     private val listeners = CopyOnWriteArrayList<(List<Playlist>, QueueOperation?) -> Unit>()
-    private val playlistListeners = mutableMapOf<String, CopyOnWriteArrayList<(Playlist, QueueOperation?) -> Unit>>()
+    private val playlistListeners = ConcurrentHashMap<String, CopyOnWriteArrayList<(Playlist, QueueOperation?) -> Unit>>()
     private var currentPlaylistId: String? = null
 
     private val saveScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -112,13 +112,16 @@ class PlaylistManager private constructor(
         description: String? = null,
         artwork: String? = null,
     ): Boolean {
-        val playlist = playlists[playlistId] ?: return false
-        playlists[playlistId] =
-            playlist.copy(
-                name = name ?: playlist.name,
-                description = description ?: playlist.description,
-                artwork = artwork ?: playlist.artwork,
-            )
+        // computeIfPresent: read-copy-put from two threads loses one edit
+        val updated =
+            playlists.computeIfPresent(playlistId) { _, playlist ->
+                playlist.copy(
+                    name = name ?: playlist.name,
+                    description = description ?: playlist.description,
+                    artwork = artwork ?: playlist.artwork,
+                )
+            } != null
+        if (!updated) return false
 
         scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.UPDATE)
@@ -146,14 +149,17 @@ class PlaylistManager private constructor(
         track: TrackItem,
         index: Int? = null,
     ): Boolean {
-        val playlist = playlists[playlistId] ?: return false
-        val tracks = playlist.tracks.toMutableList()
-        if (index != null && index >= 0 && index <= tracks.size) {
-            tracks.add(index, track)
-        } else {
-            tracks.add(track)
-        }
-        playlists[playlistId] = playlist.copy(tracks = tracks)
+        val added =
+            playlists.computeIfPresent(playlistId) { _, playlist ->
+                val tracks = playlist.tracks.toMutableList()
+                if (index != null && index >= 0 && index <= tracks.size) {
+                    tracks.add(index, track)
+                } else {
+                    tracks.add(track)
+                }
+                playlist.copy(tracks = tracks)
+            } != null
+        if (!added) return false
 
         scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.ADD)
@@ -169,14 +175,17 @@ class PlaylistManager private constructor(
         tracks: List<TrackItem>,
         index: Int? = null,
     ): Boolean {
-        val playlist = playlists[playlistId] ?: return false
-        val currentTracks = playlist.tracks.toMutableList()
-        if (index != null && index >= 0 && index <= currentTracks.size) {
-            currentTracks.addAll(index, tracks)
-        } else {
-            currentTracks.addAll(tracks)
-        }
-        playlists[playlistId] = playlist.copy(tracks = currentTracks)
+        val added =
+            playlists.computeIfPresent(playlistId) { _, playlist ->
+                val currentTracks = playlist.tracks.toMutableList()
+                if (index != null && index >= 0 && index <= currentTracks.size) {
+                    currentTracks.addAll(index, tracks)
+                } else {
+                    currentTracks.addAll(tracks)
+                }
+                playlist.copy(tracks = currentTracks)
+            } != null
+        if (!added) return false
 
         scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.ADD)
@@ -191,11 +200,15 @@ class PlaylistManager private constructor(
         playlistId: String,
         trackId: String,
     ): Boolean {
-        val playlist = playlists[playlistId] ?: return false
-        val tracks = playlist.tracks.toMutableList()
-        val removed = tracks.removeAll { it.id == trackId }
-        if (removed) {
-            playlists[playlistId] = playlist.copy(tracks = tracks)
+        var removed = false
+        playlists.computeIfPresent(playlistId) { _, playlist ->
+            val tracks = playlist.tracks.toMutableList()
+            if (tracks.removeAll { it.id == trackId }) {
+                removed = true
+                playlist.copy(tracks = tracks)
+            } else {
+                playlist
+            }
         }
 
         if (removed) {
@@ -215,15 +228,20 @@ class PlaylistManager private constructor(
         trackId: String,
         newIndex: Int,
     ): Boolean {
-        val playlist = playlists[playlistId] ?: return false
-        val tracks = playlist.tracks.toMutableList()
-        val oldIndex = tracks.indexOfFirst { it.id == trackId }
-        if (oldIndex < 0 || newIndex < 0 || newIndex >= tracks.size) {
-            return false
+        var reordered = false
+        playlists.computeIfPresent(playlistId) { _, playlist ->
+            val tracks = playlist.tracks.toMutableList()
+            val oldIndex = tracks.indexOfFirst { it.id == trackId }
+            if (oldIndex < 0 || newIndex < 0 || newIndex >= tracks.size) {
+                playlist
+            } else {
+                val track = tracks.removeAt(oldIndex)
+                tracks.add(newIndex, track)
+                reordered = true
+                playlist.copy(tracks = tracks)
+            }
         }
-        val track = tracks.removeAt(oldIndex)
-        tracks.add(newIndex, track)
-        playlists[playlistId] = playlist.copy(tracks = tracks)
+        if (!reordered) return false
 
         scheduleSave()
         notifyPlaylistChanged(playlistId, QueueOperation.UPDATE)
@@ -241,17 +259,19 @@ class PlaylistManager private constructor(
         val tracksMap = tracks.associateBy { it.id }
         val affectedPlaylists = mutableMapOf<String, Int>()
 
-        playlists.forEach { (playlistId, playlist) ->
-            var updateCount = 0
-            val newTracks =
-                playlist.tracks
-                    .map { track ->
+        for (playlistId in playlists.keys) {
+            playlists.computeIfPresent(playlistId) { _, playlist ->
+                var updateCount = 0
+                val newTracks =
+                    playlist.tracks.map { track ->
                         tracksMap[track.id]?.also { updateCount++ } ?: track
-                    }.toMutableList()
-
-            if (updateCount > 0) {
-                affectedPlaylists[playlistId] = updateCount
-                playlists[playlistId] = playlist.copy(tracks = newTracks)
+                    }
+                if (updateCount > 0) {
+                    affectedPlaylists[playlistId] = updateCount
+                    playlist.copy(tracks = newTracks)
+                } else {
+                    playlist
+                }
             }
         }
 
@@ -322,7 +342,7 @@ class PlaylistManager private constructor(
         playlistId: String,
         listener: (Playlist, QueueOperation?) -> Unit,
     ): () -> Unit {
-        val playlistListeners = playlistListeners.getOrPut(playlistId) { CopyOnWriteArrayList() }
+        val playlistListeners = playlistListeners.computeIfAbsent(playlistId) { CopyOnWriteArrayList() }
         playlistListeners.add(listener)
         return { playlistListeners.remove(listener) }
     }

--- a/react-native-nitro-player/ios/playlist/PlaylistManager.swift
+++ b/react-native-nitro-player/ios/playlist/PlaylistManager.swift
@@ -14,7 +14,13 @@ class PlaylistManager {
   private var listeners: [(String, ([PlaylistModel], QueueOperation?) -> Void)] = []
   private var playlistListeners: [String: [(String, (PlaylistModel, QueueOperation?) -> Void)]] =
     [:]
-  private var currentPlaylistId: String?
+  // Backing store must only be touched inside `queue`; every current use of the
+  // computed property is outside a queue.sync block, so the accessors can sync.
+  private var _currentPlaylistId: String?
+  private var currentPlaylistId: String? {
+    get { queue.sync { _currentPlaylistId } }
+    set { queue.sync { _currentPlaylistId = newValue } }
+  }
   private let queue = DispatchQueue(label: "com.margelo.nitro.nitroplayer.playlist")
   private var saveDebounceWorkItem: DispatchWorkItem?
 
@@ -45,15 +51,16 @@ class PlaylistManager {
    * Delete a playlist
    */
   func deletePlaylist(playlistId: String) -> Bool {
-    let removed = queue.sync {
-      return playlists.removeValue(forKey: playlistId) != nil
+    let removed = queue.sync { () -> Bool in
+      guard playlists.removeValue(forKey: playlistId) != nil else { return false }
+      if _currentPlaylistId == playlistId {
+        _currentPlaylistId = nil
+      }
+      playlistListeners.removeValue(forKey: playlistId)
+      return true
     }
 
     if removed {
-      if currentPlaylistId == playlistId {
-        currentPlaylistId = nil
-      }
-      playlistListeners.removeValue(forKey: playlistId)
       scheduleSave()
       notifyPlaylistsChanged(.remove)
       return true
@@ -68,11 +75,9 @@ class PlaylistManager {
   func updatePlaylist(
     playlistId: String, name: String? = nil, description: String? = nil, artwork: String? = nil
   ) -> Bool {
-    guard let playlist = queue.sync(execute: { playlists[playlistId] }) else {
-      return false
-    }
-
-    queue.sync {
+    // Single sync: a separate fetch-then-store loses one of two concurrent edits
+    let updated = queue.sync { () -> Bool in
+      guard let playlist = playlists[playlistId] else { return false }
       playlists[playlistId] = PlaylistModel(
         id: playlist.id,
         name: name ?? playlist.name,
@@ -80,7 +85,9 @@ class PlaylistManager {
         artwork: artwork ?? playlist.artwork,
         tracks: playlist.tracks
       )
+      return true
     }
+    guard updated else { return false }
 
     scheduleSave()
     notifyPlaylistChanged(playlistId, .update)
@@ -111,11 +118,8 @@ class PlaylistManager {
    * Add a track to a playlist
    */
   func addTrackToPlaylist(playlistId: String, track: TrackItem, index: Int? = nil) -> Bool {
-    guard let playlist = queue.sync(execute: { playlists[playlistId] }) else {
-      return false
-    }
-
-    queue.sync {
+    let added = queue.sync { () -> Bool in
+      guard let playlist = playlists[playlistId] else { return false }
       var tracks = playlist.tracks
       if let index = index, index >= 0 && index <= tracks.count {
         tracks.insert(track, at: index)
@@ -129,7 +133,9 @@ class PlaylistManager {
         artwork: playlist.artwork,
         tracks: tracks
       )
+      return true
     }
+    guard added else { return false }
 
     scheduleSave()
     notifyPlaylistChanged(playlistId, .add)
@@ -146,11 +152,8 @@ class PlaylistManager {
    * Add multiple tracks to a playlist at once
    */
   func addTracksToPlaylist(playlistId: String, tracks: [TrackItem], index: Int? = nil) -> Bool {
-    guard let playlist = queue.sync(execute: { playlists[playlistId] }) else {
-      return false
-    }
-
-    queue.sync {
+    let added = queue.sync { () -> Bool in
+      guard let playlist = playlists[playlistId] else { return false }
       var currentTracks = playlist.tracks
       if let index = index, index >= 0 && index <= currentTracks.count {
         currentTracks.insert(contentsOf: tracks, at: index)
@@ -164,7 +167,9 @@ class PlaylistManager {
         artwork: playlist.artwork,
         tracks: currentTracks
       )
+      return true
     }
+    guard added else { return false }
 
     scheduleSave()
     notifyPlaylistChanged(playlistId, .add)
@@ -182,11 +187,8 @@ class PlaylistManager {
    * Remove a track from a playlist
    */
   func removeTrackFromPlaylist(playlistId: String, trackId: String) -> Bool {
-    guard let playlist = queue.sync(execute: { playlists[playlistId] }) else {
-      return false
-    }
-
-    let removed = queue.sync {
+    let removed = queue.sync { () -> Bool in
+      guard let playlist = playlists[playlistId] else { return false }
       var tracks = playlist.tracks
       let initialCount = tracks.count
       tracks.removeAll { $0.id == trackId }
@@ -222,30 +224,27 @@ class PlaylistManager {
    * Reorder a track in a playlist
    */
   func reorderTrackInPlaylist(playlistId: String, trackId: String, newIndex: Int) -> Bool {
-    guard let playlist = queue.sync(execute: { playlists[playlistId] }) else {
-      return false
-    }
-
-    let tracks = playlist.tracks
-    guard let oldIndex = tracks.firstIndex(where: { $0.id == trackId }),
-      newIndex >= 0 && newIndex < tracks.count
-    else {
-      return false
-    }
-
-    queue.sync {
-      var reorderedTracks = tracks
-      let track = reorderedTracks.remove(at: oldIndex)
-      reorderedTracks.insert(track, at: newIndex)
+    let reordered = queue.sync { () -> Bool in
+      guard let playlist = playlists[playlistId] else { return false }
+      var tracks = playlist.tracks
+      guard let oldIndex = tracks.firstIndex(where: { $0.id == trackId }),
+        newIndex >= 0 && newIndex < tracks.count
+      else {
+        return false
+      }
+      let track = tracks.remove(at: oldIndex)
+      tracks.insert(track, at: newIndex)
 
       playlists[playlistId] = PlaylistModel(
         id: playlist.id,
         name: playlist.name,
         description: playlist.description,
         artwork: playlist.artwork,
-        tracks: reorderedTracks
+        tracks: tracks
       )
+      return true
     }
+    guard reordered else { return false }
 
     scheduleSave()
     notifyPlaylistChanged(playlistId, .update)
@@ -417,9 +416,11 @@ class PlaylistManager {
   }
 
   private func scheduleSave() {
-    saveDebounceWorkItem?.cancel()
     let work = DispatchWorkItem { [weak self] in self?.saveToFile() }
-    saveDebounceWorkItem = work
+    queue.sync {
+      saveDebounceWorkItem?.cancel()
+      saveDebounceWorkItem = work
+    }
     // Use global background queue — saveToFile calls queue.sync internally,
     // which would deadlock if scheduled on queue itself.
     DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3, execute: work)
@@ -459,7 +460,7 @@ class PlaylistManager {
       }
       let wrapper: [String: Any] = [
         "playlists": playlistsData,
-        "currentPlaylistId": currentPlaylistId as Any,
+        "currentPlaylistId": queue.sync { _currentPlaylistId } as Any,
       ]
       let data = try JSONSerialization.data(withJSONObject: wrapper, options: [])
       try NitroPlayerStorage.write(filename: "playlists.json", data: data)


### PR DESCRIPTION
## Problems (agreed list RC-2 #8)
**iOS** (`ios/playlist/PlaylistManager.swift`):
- `currentPlaylistId`, `playlistListeners` (in `deletePlaylist`), and `saveDebounceWorkItem` were read/written from the JS thread, playerQueue, and the background save queue with no synchronization — concurrent dictionary mutation crash risk.
- Every mutation fetched the playlist in one `queue.sync` and wrote it back in a second — two concurrent mutations lost one update.

**Android** (`playlist/PlaylistManager.kt`):
- Mutations followed read-copy-put on a `ConcurrentHashMap` (not atomic); `addTrackToPlaylist` runs on `Promise.async` pool threads while `updateTracks` runs on the player thread — lost updates.
- `playlistListeners` was a plain `mutableMapOf` written from the JS thread and iterated from notify paths — `ConcurrentModificationException` risk.

## Fix
- iOS: `currentPlaylistId` is now a queue-backed computed property (all uses verified to be outside `queue.sync`); `deletePlaylist` does removal + current-id clear + listener cleanup in one sync; each fetch-then-store merged into a single `queue.sync`; debounce work item swapped under the queue.
- Android: all five mutators (and `updateTracks`) use atomic `computeIfPresent`; `playlistListeners` is a `ConcurrentHashMap` with `computeIfAbsent` registration.

Stacked on #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)