### PR TITLE
fix: EQ gains raced between JS thread and the realtime audio tap

### DIFF
--- a/react-native-nitro-player/ios/equalizer/EqualizerCore.swift
+++ b/react-native-nitro-player/ios/equalizer/EqualizerCore.swift
@@ -28,6 +28,27 @@ class EqualizerCore {
 
   // Current gains storage - internal so TapContext can access
   private(set) var currentGains: [Double] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+  // Guards currentGains/gainsDirty between the JS thread (slider writes) and the
+  // MTAudioProcessingTap render thread — unsynchronized Swift Array access is a
+  // CoW data race (torn coefficients, loud glitches, rare crashes)
+  private var gainsLock = os_unfair_lock_s()
+
+  func withGainsLock<T>(_ body: () -> T) -> T {
+    os_unfair_lock_lock(&gainsLock)
+    defer { os_unfair_lock_unlock(&gainsLock) }
+    return body()
+  }
+
+  /// Render-thread accessor: returns a snapshot of the gains and clears the dirty
+  /// flag atomically, or nil when nothing changed.
+  func consumeDirtyGains() -> [Double]? {
+    return withGainsLock {
+      guard gainsDirty else { return nil }
+      gainsDirty = false
+      return currentGains
+    }
+  }
   private var cachedBands: [EqualizerBand]?
   private var cachedCustomPresets: [EqualizerPreset]?
 
@@ -209,9 +230,11 @@ class EqualizerCore {
     guard bandIndex >= 0 && bandIndex < 10 else { return false }
 
     let clampedGain = max(-12.0, min(12.0, gainDb))
-    currentGains[bandIndex] = clampedGain
+    withGainsLock {
+      currentGains[bandIndex] = clampedGain
+      gainsDirty = true
+    }
     cachedBands = nil
-    gainsDirty = true
 
     currentPresetName = nil
     notifyBandChange(getBands())
@@ -226,11 +249,13 @@ class EqualizerCore {
   func setAllBandGains(_ gains: [Double]) -> Bool {
     guard gains.count == 10 else { return false }
 
-    for i in 0..<10 {
-      currentGains[i] = max(-12.0, min(12.0, gains[i]))
+    withGainsLock {
+      for i in 0..<10 {
+        currentGains[i] = max(-12.0, min(12.0, gains[i]))
+      }
+      gainsDirty = true
     }
     cachedBands = nil
-    gainsDirty = true
 
     notifyBandChange(getBands())
     saveBandGains(currentGains)
@@ -406,7 +431,10 @@ class EqualizerCore {
       let gains = try? JSONDecoder().decode([Double].self, from: data),
       gains.count == 10
     {
-      currentGains = gains
+      withGainsLock {
+        currentGains = gains
+        gainsDirty = true
+      }
     }
     // else: migration from 5-band or fresh install — start at flat (currentGains already zeroed)
 
@@ -478,9 +506,10 @@ private class TapContext {
   }
 
   func updateCoefficients() {
-    guard let eqCore = eqCore else { return }
+    // Snapshot + dirty-clear happen atomically under the gains lock; nil means
+    // another consumer already took this change
+    guard let gains = eqCore?.consumeDirtyGains() else { return }
     let frequencies: [Float] = [31, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
-    let gains = eqCore.currentGains
 
     for i in 0..<10 {
       filterCoeffs[i] = calculatePeakingEQCoefficients(
@@ -490,7 +519,6 @@ private class TapContext {
         sampleRate: Double(sampleRate)
       )
     }
-    eqCore.gainsDirty = false
   }
 
   /// Calculate biquad coefficients for a peaking EQ filter


### PR DESCRIPTION
## Problem
`currentGains` (Swift `Array`), `gainsDirty`, and `isEqualizerEnabled` were read from the MTAudioProcessingTap process callback (Core Audio render thread) while `setBandGain`/`setAllBandGains` mutated them on the JS thread with no synchronization. Dragging an EQ slider during playback is a CoW write/read race — torn reads produce garbage biquad coefficients (loud glitch or full-scale output) or a rare crash.

## Fix
- `os_unfair_lock` guards `currentGains` + `gainsDirty`; all writers (slider, preset restore) mutate under the lock.
- New `consumeDirtyGains()` snapshots the gains and clears the dirty flag atomically; `updateCoefficients` uses the snapshot, so the render thread never touches the shared array. The unsynchronized `gainsDirty` fast-path check in the tap remains as a hint only (worst case one frame of delay).

Deliberate ceiling: the coefficient recompute still allocates small arrays — but only on an actual gain change, never in steady-state render. `isEqualizerEnabled` stays a plain Bool (single-byte read, benign).

Stacked on #159. Agreed list RC-2 #7 (Fable/Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)