### PR TITLE
fix: native HybridObject callbacks leak into dead JS runtimes across reloads

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridDownloadManager.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridDownloadManager.kt
@@ -129,9 +129,29 @@ class HybridDownloadManager : HybridDownloadManagerSpec() {
     override fun getPlaybackSourcePreference(): PlaybackSource = core.getPlaybackSourcePreference()
 
     // ── Events ────────────────────────────────────────────────────────────────
-    override fun onDownloadProgress(callback: (progress: DownloadProgress) -> Unit) = core.addProgressCallback(callback)
+    private val listenerIds = java.util.concurrent.CopyOnWriteArrayList<Pair<String, Long>>()
 
-    override fun onDownloadStateChange(callback: (downloadId: String, trackId: String, state: DownloadState, error: DownloadError?) -> Unit) = core.addStateChangeCallback(callback)
+    override fun onDownloadProgress(callback: (progress: DownloadProgress) -> Unit) {
+        listenerIds.add("progress" to core.addProgressCallback(callback))
+    }
 
-    override fun onDownloadComplete(callback: (downloadedTrack: DownloadedTrack) -> Unit) = core.addCompleteCallback(callback)
+    override fun onDownloadStateChange(callback: (downloadId: String, trackId: String, state: DownloadState, error: DownloadError?) -> Unit) {
+        listenerIds.add("state" to core.addStateChangeCallback(callback))
+    }
+
+    override fun onDownloadComplete(callback: (downloadedTrack: DownloadedTrack) -> Unit) {
+        listenerIds.add("complete" to core.addCompleteCallback(callback))
+    }
+
+    override fun dispose() {
+        super.dispose()
+        listenerIds.forEach { (type, id) ->
+            when (type) {
+                "progress" -> core.removeProgressCallback(id)
+                "state" -> core.removeStateChangeCallback(id)
+                "complete" -> core.removeCompleteCallback(id)
+            }
+        }
+        listenerIds.clear()
+    }
 }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridEqualizer.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridEqualizer.kt
@@ -63,9 +63,29 @@ class HybridEqualizer : HybridEqualizerSpec() {
     override fun reset(): Promise<Unit> = Promise.async { core.reset() }
 
     // ── Events ────────────────────────────────────────────────────────────────
-    override fun onEnabledChange(callback: (enabled: Boolean) -> Unit) = core.addOnEnabledChangeListener(callback)
+    private val listenerIds = java.util.concurrent.CopyOnWriteArrayList<Pair<String, Long>>()
 
-    override fun onBandChange(callback: (bands: Array<EqualizerBand>) -> Unit) = core.addOnBandChangeListener(callback)
+    override fun onEnabledChange(callback: (enabled: Boolean) -> Unit) {
+        listenerIds.add("enabled" to core.addOnEnabledChangeListener(callback))
+    }
 
-    override fun onPresetChange(callback: (presetName: Variant_NullType_String?) -> Unit) = core.addOnPresetChangeListener(callback)
+    override fun onBandChange(callback: (bands: Array<EqualizerBand>) -> Unit) {
+        listenerIds.add("band" to core.addOnBandChangeListener(callback))
+    }
+
+    override fun onPresetChange(callback: (presetName: Variant_NullType_String?) -> Unit) {
+        listenerIds.add("preset" to core.addOnPresetChangeListener(callback))
+    }
+
+    override fun dispose() {
+        super.dispose()
+        listenerIds.forEach { (type, id) ->
+            when (type) {
+                "enabled" -> core.removeOnEnabledChangeListener(id)
+                "band" -> core.removeOnBandChangeListener(id)
+                "preset" -> core.removeOnPresetChangeListener(id)
+            }
+        }
+        listenerIds.clear()
+    }
 }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
@@ -11,7 +11,6 @@ import com.margelo.nitro.nitroplayer.core.TrackPlayerCore
 import com.margelo.nitro.nitroplayer.core.loadPlaylistOnQueue
 import com.margelo.nitro.nitroplayer.core.updatePlaylist
 import com.margelo.nitro.nitroplayer.playlist.PlaylistManager
-import java.util.UUID
 import com.margelo.nitro.nitroplayer.playlist.Playlist as InternalPlaylist
 
 @DoNotStrip
@@ -29,7 +28,6 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
     }
 
     private val playlistsChangeListeners = java.util.concurrent.CopyOnWriteArrayList<() -> Unit>()
-    private val playlistChangeListeners = java.util.concurrent.ConcurrentHashMap<String, () -> Unit>()
 
     // ── Playlist CRUD ─────────────────────────────────────────────────────────
 
@@ -148,14 +146,19 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
     }
 
     override fun onPlaylistChanged(callback: (playlistId: String, playlist: Playlist, operation: QueueOperation?) -> Unit) {
-        val listenerId = UUID.randomUUID().toString()
-        playlistManager.getAllPlaylists().forEach { internalPlaylist ->
-            val removeListener =
-                playlistManager.addPlaylistChangeListener(internalPlaylist.id) { playlist, operation ->
-                    callback(playlist.id, playlist.toPlaylist(), operation)
-                }
-            playlistChangeListeners[listenerId] = removeListener
-        }
+        // Manager-level listener: covers playlists created after registration,
+        // and one remover per callback instead of one per playlist
+        val removeListener =
+            playlistManager.addAnyPlaylistChangeListener { playlist, operation ->
+                callback(playlist.id, playlist.toPlaylist(), operation)
+            }
+        playlistsChangeListeners.add(removeListener)
+    }
+
+    override fun dispose() {
+        super.dispose()
+        playlistsChangeListeners.forEach { it() }
+        playlistsChangeListeners.clear()
     }
 
     // ── Helper ────────────────────────────────────────────────────────────────

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.work.*
 import com.margelo.nitro.core.NullType
 import com.margelo.nitro.nitroplayer.*
+import com.margelo.nitro.nitroplayer.core.ListenerRegistry
 import com.margelo.nitro.nitroplayer.core.NitroPlayerLogger
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -52,10 +53,11 @@ class DownloadManagerCore private constructor(
     private val trackMetadata = ConcurrentHashMap<String, TrackItem>()
     private val playlistAssociations = ConcurrentHashMap<String, String>()
 
-    // Callbacks
-    private val progressCallbacks = CopyOnWriteArrayList<(DownloadProgress) -> Unit>()
-    private val stateChangeCallbacks = CopyOnWriteArrayList<(String, String, DownloadState, DownloadError?) -> Unit>()
-    private val completeCallbacks = CopyOnWriteArrayList<(DownloadedTrack) -> Unit>()
+    // Callbacks — ListenerRegistry so HybridDownloadManager.dispose can remove
+    // them instead of leaking closures into dead JS runtimes across reloads
+    private val progressCallbacks = ListenerRegistry<(DownloadProgress) -> Unit>()
+    private val stateChangeCallbacks = ListenerRegistry<(String, String, DownloadState, DownloadError?) -> Unit>()
+    private val completeCallbacks = ListenerRegistry<(DownloadedTrack) -> Unit>()
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private val database = DownloadDatabase.getInstance(context)
@@ -360,17 +362,17 @@ class DownloadManagerCore private constructor(
         }
 
     // Callbacks
-    fun addProgressCallback(callback: (DownloadProgress) -> Unit) {
-        progressCallbacks.add(callback)
-    }
+    fun addProgressCallback(callback: (DownloadProgress) -> Unit): Long = progressCallbacks.add(callback)
 
-    fun addStateChangeCallback(callback: (String, String, DownloadState, DownloadError?) -> Unit) {
-        stateChangeCallbacks.add(callback)
-    }
+    fun removeProgressCallback(id: Long): Boolean = progressCallbacks.remove(id)
 
-    fun addCompleteCallback(callback: (DownloadedTrack) -> Unit) {
-        completeCallbacks.add(callback)
-    }
+    fun addStateChangeCallback(callback: (String, String, DownloadState, DownloadError?) -> Unit): Long = stateChangeCallbacks.add(callback)
+
+    fun removeStateChangeCallback(id: Long): Boolean = stateChangeCallbacks.remove(id)
+
+    fun addCompleteCallback(callback: (DownloadedTrack) -> Unit): Long = completeCallbacks.add(callback)
+
+    fun removeCompleteCallback(id: Long): Boolean = completeCallbacks.remove(id)
 
     // Internal callbacks from DownloadWorker
     internal fun onProgress(

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/equalizer/EqualizerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/equalizer/EqualizerCore.kt
@@ -475,17 +475,17 @@ class EqualizerCore private constructor(
 
     // === Callback management ===
 
-    fun addOnEnabledChangeListener(callback: (Boolean) -> Unit) {
-        onEnabledChangeListeners.add(callback)
-    }
+    fun addOnEnabledChangeListener(callback: (Boolean) -> Unit): Long = onEnabledChangeListeners.add(callback)
 
-    fun addOnBandChangeListener(callback: (Array<EqualizerBand>) -> Unit) {
-        onBandChangeListeners.add(callback)
-    }
+    fun removeOnEnabledChangeListener(id: Long): Boolean = onEnabledChangeListeners.remove(id)
 
-    fun addOnPresetChangeListener(callback: (Variant_NullType_String?) -> Unit) {
-        onPresetChangeListeners.add(callback)
-    }
+    fun addOnBandChangeListener(callback: (Array<EqualizerBand>) -> Unit): Long = onBandChangeListeners.add(callback)
+
+    fun removeOnBandChangeListener(id: Long): Boolean = onBandChangeListeners.remove(id)
+
+    fun addOnPresetChangeListener(callback: (Variant_NullType_String?) -> Unit): Long = onPresetChangeListeners.add(callback)
+
+    fun removeOnPresetChangeListener(id: Long): Boolean = onPresetChangeListeners.remove(id)
 
     private fun notifyEnabledChange(enabled: Boolean) {
         onEnabledChangeListeners.forEach { it(enabled) }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
@@ -347,6 +347,14 @@ class PlaylistManager private constructor(
         return { playlistListeners.remove(listener) }
     }
 
+    private val anyPlaylistListeners = CopyOnWriteArrayList<(Playlist, QueueOperation?) -> Unit>()
+
+    /** Fires for changes to ANY playlist, including ones created after registration. */
+    fun addAnyPlaylistChangeListener(listener: (Playlist, QueueOperation?) -> Unit): () -> Unit {
+        anyPlaylistListeners.add(listener)
+        return { anyPlaylistListeners.remove(listener) }
+    }
+
     private fun notifyPlaylistsChanged(operation: QueueOperation?) {
         listeners.forEach { it(playlists.values.toList(), operation) }
     }
@@ -357,6 +365,7 @@ class PlaylistManager private constructor(
     ) {
         val playlist = playlists[playlistId] ?: return
         playlistListeners[playlistId]?.forEach { it(playlist, operation) }
+        anyPlaylistListeners.forEach { it(playlist, operation) }
     }
 
     // MARK: - Persistence

--- a/react-native-nitro-player/ios/HybridDownloadManager.swift
+++ b/react-native-nitro-player/ios/HybridDownloadManager.swift
@@ -213,20 +213,30 @@ final class HybridDownloadManager: HybridDownloadManagerSpec {
 
   // MARK: - Event Callbacks
 
+  private var progressCallbackIds: [UUID] = []
+  private var stateChangeCallbackIds: [UUID] = []
+  private var completeCallbackIds: [UUID] = []
+
   func onDownloadProgress(callback: @escaping (DownloadProgress) -> Void) throws {
     NitroPlayerLogger.log("HybridDownloadManager", "onDownloadProgress callback registered")
-    core.addProgressCallback(callback)
+    progressCallbackIds.append(core.addProgressCallback(callback))
   }
 
   func onDownloadStateChange(
     callback: @escaping (String, String, DownloadState, DownloadError?) -> Void
   ) throws {
     NitroPlayerLogger.log("HybridDownloadManager", "onDownloadStateChange callback registered")
-    core.addStateChangeCallback(callback)
+    stateChangeCallbackIds.append(core.addStateChangeCallback(callback))
   }
 
   func onDownloadComplete(callback: @escaping (DownloadedTrack) -> Void) throws {
     NitroPlayerLogger.log("HybridDownloadManager", "onDownloadComplete callback registered")
-    core.addCompleteCallback(callback)
+    completeCallbackIds.append(core.addCompleteCallback(callback))
+  }
+
+  deinit {
+    progressCallbackIds.forEach { core.removeProgressCallback(id: $0) }
+    stateChangeCallbackIds.forEach { core.removeStateChangeCallback(id: $0) }
+    completeCallbackIds.forEach { core.removeCompleteCallback(id: $0) }
   }
 }

--- a/react-native-nitro-player/ios/download/DownloadManagerCore.swift
+++ b/react-native-nitro-player/ios/download/DownloadManagerCore.swift
@@ -66,9 +66,11 @@ final class DownloadManagerCore: NSObject {
 
   // MARK: - Callbacks
 
-  private var progressCallbacks: [(DownloadProgress) -> Void] = []
-  private var stateChangeCallbacks: [(String, String, DownloadState, DownloadError?) -> Void] = []
-  private var completeCallbacks: [(DownloadedTrack) -> Void] = []
+  // Keyed so HybridDownloadManager.deinit can remove its registrations instead
+  // of leaking closures into dead JS runtimes across reloads
+  private var progressCallbacks: [(UUID, (DownloadProgress) -> Void)] = []
+  private var stateChangeCallbacks: [(UUID, (String, String, DownloadState, DownloadError?) -> Void)] = []
+  private var completeCallbacks: [(UUID, (DownloadedTrack) -> Void)] = []
 
   // MARK: - Thread Safety
 
@@ -509,23 +511,50 @@ final class DownloadManagerCore: NSObject {
 
   // MARK: - Callbacks
 
-  func addProgressCallback(_ callback: @escaping (DownloadProgress) -> Void) {
+  @discardableResult
+  func addProgressCallback(_ callback: @escaping (DownloadProgress) -> Void) -> UUID {
+    let id = UUID()
     queue.async(flags: .barrier) {
-      self.progressCallbacks.append(callback)
+      self.progressCallbacks.append((id, callback))
+    }
+    return id
+  }
+
+  func removeProgressCallback(id: UUID) {
+    queue.async(flags: .barrier) {
+      self.progressCallbacks.removeAll { $0.0 == id }
     }
   }
 
+  @discardableResult
   func addStateChangeCallback(
     _ callback: @escaping (String, String, DownloadState, DownloadError?) -> Void
-  ) {
+  ) -> UUID {
+    let id = UUID()
     queue.async(flags: .barrier) {
-      self.stateChangeCallbacks.append(callback)
+      self.stateChangeCallbacks.append((id, callback))
+    }
+    return id
+  }
+
+  func removeStateChangeCallback(id: UUID) {
+    queue.async(flags: .barrier) {
+      self.stateChangeCallbacks.removeAll { $0.0 == id }
     }
   }
 
-  func addCompleteCallback(_ callback: @escaping (DownloadedTrack) -> Void) {
+  @discardableResult
+  func addCompleteCallback(_ callback: @escaping (DownloadedTrack) -> Void) -> UUID {
+    let id = UUID()
     queue.async(flags: .barrier) {
-      self.completeCallbacks.append(callback)
+      self.completeCallbacks.append((id, callback))
+    }
+    return id
+  }
+
+  func removeCompleteCallback(id: UUID) {
+    queue.async(flags: .barrier) {
+      self.completeCallbacks.removeAll { $0.0 == id }
     }
   }
 
@@ -730,8 +759,9 @@ final class DownloadManagerCore: NSObject {
   }
 
   private func notifyProgress(_ progress: DownloadProgress) {
+    let callbacks = self.progressCallbacks
     DispatchQueue.main.async {
-      for callback in self.progressCallbacks {
+      for (_, callback) in callbacks {
         callback(progress)
       }
     }
@@ -740,16 +770,18 @@ final class DownloadManagerCore: NSObject {
   private func notifyStateChange(
     downloadId: String, trackId: String, state: DownloadState, error: DownloadError?
   ) {
+    let callbacks = self.stateChangeCallbacks
     DispatchQueue.main.async {
-      for callback in self.stateChangeCallbacks {
+      for (_, callback) in callbacks {
         callback(downloadId, trackId, state, error)
       }
     }
   }
 
   private func notifyComplete(_ downloadedTrack: DownloadedTrack) {
+    let callbacks = self.completeCallbacks
     DispatchQueue.main.async {
-      for callback in self.completeCallbacks {
+      for (_, callback) in callbacks {
         callback(downloadedTrack)
       }
     }


### PR DESCRIPTION
## Problem (agreed list RC-1 #2, Codex finding B)
`HybridEqualizer` + `HybridDownloadManager` (Android) and `HybridDownloadManager` (iOS) registered callbacks into process-lifetime singletons with no remove API and no `dispose()`/`deinit` — every JS reload added another copy: leaked closures into dead runtimes, duplicated event delivery. `HybridTrackPlayer`/`HybridCast` already did this correctly; these were missed.

`HybridPlayerQueue.onPlaylistChanged` (Android) had three further defects: registered only on playlists existing at call time (later-created playlists never emitted), stored every per-playlist remover under one `listenerId` key (all but the last unreachable), and had no `dispose()`.

## Fix
- Android: `EqualizerCore` add-methods return registry IDs + remove methods; `DownloadManagerCore` callbacks moved from `CopyOnWriteArrayList` to the existing `ListenerRegistry`; both Hybrids record IDs and release them in `dispose()` (mirroring HybridTrackPlayer).
- Android: new manager-level `addAnyPlaylistChangeListener` in `PlaylistManager` fires for changes to any playlist, including future ones; `HybridPlayerQueue` registers one listener per callback and releases all removers in `dispose()`.
- iOS: `DownloadManagerCore` callbacks keyed by `UUID` with barrier-safe remove; `HybridDownloadManager` releases its registrations in `deinit`.

Durable follow-up (out of scope here, per review consensus): Nitro specs returning an idempotent `ListenerSubscription` instead of `void`.

Stacked on #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)