### PR TITLE
fix: invalid playlist operations resolve successfully on both platforms

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/HybridPlayerQueue.kt
@@ -39,7 +39,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
 
     override fun deletePlaylist(playlistId: String): Promise<Unit> =
         Promise.async {
-            playlistManager.deletePlaylist(playlistId)
+            if (!playlistManager.deletePlaylist(playlistId)) {
+                throw IllegalArgumentException("Playlist not found: $playlistId")
+            }
         }
 
     override fun updatePlaylist(
@@ -49,7 +51,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         artwork: String?,
     ): Promise<Unit> =
         Promise.async {
-            playlistManager.updatePlaylist(playlistId, name, description, artwork)
+            if (!playlistManager.updatePlaylist(playlistId, name, description, artwork)) {
+                throw IllegalArgumentException("Playlist not found: $playlistId")
+            }
             core.updatePlaylist(playlistId)
         }
 
@@ -72,7 +76,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         index: Double?,
     ): Promise<Unit> =
         Promise.async {
-            playlistManager.addTrackToPlaylist(playlistId, track, index?.toInt())
+            if (!playlistManager.addTrackToPlaylist(playlistId, track, index?.toInt())) {
+                throw IllegalArgumentException("Playlist not found: $playlistId")
+            }
             core.updatePlaylist(playlistId)
         }
 
@@ -82,7 +88,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         index: Double?,
     ): Promise<Unit> =
         Promise.async {
-            playlistManager.addTracksToPlaylist(playlistId, tracks.toList(), index?.toInt())
+            if (!playlistManager.addTracksToPlaylist(playlistId, tracks.toList(), index?.toInt())) {
+                throw IllegalArgumentException("Playlist not found: $playlistId")
+            }
             core.updatePlaylist(playlistId)
         }
 
@@ -91,7 +99,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         trackId: String,
     ): Promise<Unit> =
         Promise.async {
-            playlistManager.removeTrackFromPlaylist(playlistId, trackId)
+            if (!playlistManager.removeTrackFromPlaylist(playlistId, trackId)) {
+                throw IllegalArgumentException("Track $trackId not found in playlist $playlistId")
+            }
             core.updatePlaylist(playlistId)
         }
 
@@ -101,7 +111,9 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         newIndex: Double,
     ): Promise<Unit> =
         Promise.async {
-            playlistManager.reorderTrackInPlaylist(playlistId, trackId, newIndex.toInt())
+            if (!playlistManager.reorderTrackInPlaylist(playlistId, trackId, newIndex.toInt())) {
+                throw IllegalArgumentException("Invalid reorder for track $trackId in playlist $playlistId")
+            }
             core.updatePlaylist(playlistId)
         }
 
@@ -120,8 +132,10 @@ class HybridPlayerQueue : HybridPlayerQueueSpec() {
         core.enqueue {
             if (playlistManager.loadPlaylist(playlistId, startIndex)) {
                 core.loadPlaylistOnQueue(playlistId, startIndex)
+                promise.resolve(Unit)
+            } else {
+                promise.reject(IllegalArgumentException("Invalid playlist or index: $playlistId"))
             }
-            promise.resolve(Unit)
         }
         return promise
     }

--- a/react-native-nitro-player/ios/queue/HybridPlayerQueue.swift
+++ b/react-native-nitro-player/ios/queue/HybridPlayerQueue.swift
@@ -22,13 +22,20 @@ final class HybridPlayerQueue: HybridPlayerQueueSpec {
   }
 
   func deletePlaylist(playlistId: String) throws -> Promise<Void> {
-    Promise.async { _ = self.playlistManager.deletePlaylist(playlistId: playlistId) }
+    Promise.async {
+      guard self.playlistManager.deletePlaylist(playlistId: playlistId) else {
+        throw RuntimeError.error(withMessage: "Playlist not found: \(playlistId)")
+      }
+    }
   }
 
   func updatePlaylist(playlistId: String, name: String?, description: String?, artwork: String?) throws -> Promise<Void> {
     Promise.async {
-      _ = self.playlistManager.updatePlaylist(
+      guard self.playlistManager.updatePlaylist(
         playlistId: playlistId, name: name, description: description, artwork: artwork)
+      else {
+        throw RuntimeError.error(withMessage: "Playlist not found: \(playlistId)")
+      }
       self.core.updatePlaylist(playlistId: playlistId)
     }
   }
@@ -48,29 +55,41 @@ final class HybridPlayerQueue: HybridPlayerQueueSpec {
 
   func addTrackToPlaylist(playlistId: String, track: TrackItem, index: Double?) throws -> Promise<Void> {
     Promise.async {
-      _ = self.playlistManager.addTrackToPlaylist(playlistId: playlistId, track: track, index: index.map { Int($0) })
+      guard self.playlistManager.addTrackToPlaylist(playlistId: playlistId, track: track, index: index.map { Int($0) })
+      else {
+        throw RuntimeError.error(withMessage: "Playlist not found: \(playlistId)")
+      }
       self.core.updatePlaylist(playlistId: playlistId)
     }
   }
 
   func addTracksToPlaylist(playlistId: String, tracks: [TrackItem], index: Double?) throws -> Promise<Void> {
     Promise.async {
-      _ = self.playlistManager.addTracksToPlaylist(playlistId: playlistId, tracks: tracks, index: index.map { Int($0) })
+      guard self.playlistManager.addTracksToPlaylist(playlistId: playlistId, tracks: tracks, index: index.map { Int($0) })
+      else {
+        throw RuntimeError.error(withMessage: "Playlist not found: \(playlistId)")
+      }
       self.core.updatePlaylist(playlistId: playlistId)
     }
   }
 
   func removeTrackFromPlaylist(playlistId: String, trackId: String) throws -> Promise<Void> {
     Promise.async {
-      _ = self.playlistManager.removeTrackFromPlaylist(playlistId: playlistId, trackId: trackId)
+      guard self.playlistManager.removeTrackFromPlaylist(playlistId: playlistId, trackId: trackId)
+      else {
+        throw RuntimeError.error(withMessage: "Track \(trackId) not found in playlist \(playlistId)")
+      }
       self.core.updatePlaylist(playlistId: playlistId)
     }
   }
 
   func reorderTrackInPlaylist(playlistId: String, trackId: String, newIndex: Double) throws -> Promise<Void> {
     Promise.async {
-      _ = self.playlistManager.reorderTrackInPlaylist(
+      guard self.playlistManager.reorderTrackInPlaylist(
         playlistId: playlistId, trackId: trackId, newIndex: Int(newIndex))
+      else {
+        throw RuntimeError.error(withMessage: "Invalid reorder for track \(trackId) in playlist \(playlistId)")
+      }
       self.core.updatePlaylist(playlistId: playlistId)
     }
   }
@@ -86,8 +105,10 @@ final class HybridPlayerQueue: HybridPlayerQueueSpec {
       // Update PlaylistManager.currentPlaylistId so getCurrentPlaylistId() returns correctly
       if self.playlistManager.loadPlaylist(playlistId: playlistId, index: startIndex) {
         self.core.loadPlaylistOnQueue(playlistId: playlistId, startIndex: startIndex)
+        promise.resolve(withResult: ())
+      } else {
+        promise.reject(withError: RuntimeError.error(withMessage: "Invalid playlist or index: \(playlistId)"))
       }
-      promise.resolve(withResult: ())
     }
     return promise
   }


### PR DESCRIPTION
## Problem (agreed list RC-5 #25, Codex finding C)
The native managers return `Bool` for missing playlist IDs, invalid indexes, and failed mutations — but the HybridObjects discarded the result (`_ =` on iOS, bare call on Android) and resolved `Promise<void>` unconditionally. `loadPlaylist()` also resolved when the playlist/index was invalid. Callers could `await` a mutation that did nothing and continue with false state assumptions.

## Fix
Every playlist mutation (`deletePlaylist`, `updatePlaylist`, `addTrackToPlaylist`, `addTracksToPlaylist`, `removeTrackFromPlaylist`, `reorderTrackInPlaylist`) and `loadPlaylist` now rejects with a specific error message when the manager reports failure — iOS via `RuntimeError.error(withMessage:)`, Android via `IllegalArgumentException`. Success resolves only after the mutation (including the current-player queue update) is applied.

Stacked on #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)