### PR TITLE
fix: minor items — notification ID collisions, dead skipToPrevious pre-removal

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
@@ -52,23 +52,8 @@ internal fun TrackPlayerCore.skipToPreviousOnQueue() {
         }
 
         currentTemporaryType != TrackPlayerCore.TemporaryType.NONE -> {
-            val trackId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
-            if (trackId != null) {
-                when (currentTemporaryType) {
-                    TrackPlayerCore.TemporaryType.PLAY_NEXT -> {
-                        val idx = playNextStack.indexOfFirst { it.id == trackId }
-                        if (idx >= 0) playNextStack.removeAt(idx)
-                    }
-
-                    TrackPlayerCore.TemporaryType.UP_NEXT -> {
-                        val idx = upNextQueue.indexOfFirst { it.id == trackId }
-                        if (idx >= 0) upNextQueue.removeAt(idx)
-                    }
-
-                    else -> {}
-                }
-            }
-            currentTemporaryType = TrackPlayerCore.TemporaryType.NONE
+            // playFromIndexInternal clears both temp lists (matching iOS behavior),
+            // so no per-track removal is needed here
             playFromIndexInternal(currentTrackIndex)
         }
 

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadWorker.kt
@@ -67,7 +67,7 @@ class DownloadWorker(
             val urlString = inputData.getString(KEY_URL) ?: return@withContext Result.failure()
             val storageLocationStr = inputData.getString(KEY_STORAGE_LOCATION) ?: StorageLocation.PRIVATE.name
 
-            notificationId = BASE_NOTIFICATION_ID + trackId.hashCode().and(0xFFFF)
+            notificationId = BASE_NOTIFICATION_ID + trackId.hashCode().and(0x7FFFFF)
 
             val storageLocation =
                 try {


### PR DESCRIPTION
## Changes (agreed list item 40)
- Download notification IDs used a 16-bit hash (`and(0xFFFF)`) — 1-in-65k collision per track pair makes concurrent download notifications overwrite each other. Widened to 23 bits.
- `skipToPreviousOnQueue`'s temp-track pre-removal was dead code: `playFromIndexInternal` clears both temp lists unconditionally (intentional, matches iOS). The misleading block is removed with a comment stating the invariant.

**Not addressed** (needs a spec change): `getDownloadState` returns `PENDING` for tracks that were never downloaded — the `DownloadState` enum has no `NOT_DOWNLOADED` value, so fixing it means adding one to the TS spec + nitrogen regen. Flagged as follow-up.

Stacked on #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)