### PR TITLE
fix: resolve Android Kotlin compile errors on main

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
@@ -176,7 +176,7 @@ internal class TrackPlayerEventListener(
             // A source error leaves ExoPlayer in IDLE; skip the dead item and
             // re-prepare so the rest of the queue keeps playing.
             if (exo.hasNextMediaItem()) {
-                exo.seekToNextMediaItem()
+                exo.seekToNext()
                 exo.prepare()
             }
         }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/download/DownloadManagerCore.kt
@@ -165,7 +165,7 @@ class DownloadManagerCore private constructor(
             runningDownloads.remove(downloadId)
             pendingLaunchQueue.remove(downloadId)
             if (runningDownloads.size < maxConcurrent()) {
-                next = pendingLaunchQueue.removeFirstOrNull()
+                next = pendingLaunchQueue.pollFirst()
                 next?.let { runningDownloads.add(it) }
             }
         }

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/playlist/PlaylistManager.kt
@@ -268,7 +268,7 @@ class PlaylistManager private constructor(
                     }
                 if (updateCount > 0) {
                     affectedPlaylists[playlistId] = updateCount
-                    playlist.copy(tracks = newTracks)
+                    playlist.copy(tracks = newTracks.toMutableList())
                 } else {
                     playlist
                 }


### PR DESCRIPTION
Fixes Android Build failure on main ([run](https://github.com/riteshshukla04/react-native-nitro-player/actions/runs/32657197759)).

- `TrackPlayerListener.kt`: `exo` is the `ExoPlayerCore` wrapper — use its `seekToNext()` instead of `seekToNextMediaItem()`
- `DownloadManagerCore.kt`: `ArrayDeque` resolves to `java.util.ArrayDeque` via wildcard import — use `pollFirst()` instead of `removeFirstOrNull()`
- `PlaylistManager.kt`: `.map` returns `List` but `Playlist.tracks` is `MutableList` — add `.toMutableList()`

Verified locally: `:react-native-nitro-player:compileDebugKotlin` passes with `--rerun-tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)