### PR TITLE
fix: gapless loop when playlist repeat wraps to the start of the queue

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerListener.kt
@@ -58,11 +58,15 @@ internal class TrackPlayerEventListener(
             currentTemporaryType = determineCurrentTemporaryType()
 
             // Update currentTrackIndex when landing on an original playlist track
+            val previousTrackIndex = currentTrackIndex
             if (currentTemporaryType == TrackPlayerCore.TemporaryType.NONE && mediaItem != null) {
                 val trackId = extractTrackId(mediaItem.mediaId)
                 val newIdx = currentTracks.indexOfFirst { it.id == trackId }
                 if (newIdx >= 0 && newIdx != currentTrackIndex) currentTrackIndex = newIdx
             }
+
+            val wrappedToStart = currentRepeatMode == RepeatMode.PLAYLIST &&
+                currentTrackIndex == 0 && previousTrackIndex == currentTracks.size - 1
 
             // Top up the windowed timeline — the item we just left freed a slot.
             // Only when it is actually short: rebuildQueueFromCurrentPosition can fall
@@ -77,7 +81,8 @@ internal class TrackPlayerEventListener(
             val track = getCurrentTrack() ?: return
             val r =
                 when (reason) {
-                    Player.MEDIA_ITEM_TRANSITION_REASON_AUTO -> Reason.END
+                    Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ->
+                        if (wrappedToStart) Reason.REPEAT else Reason.END
                     Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> Reason.USER_ACTION
                     Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED -> Reason.USER_ACTION
                     else -> null

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerPlayback.kt
@@ -74,6 +74,7 @@ internal fun TrackPlayerCore.skipToPreviousOnQueue() {
 suspend fun TrackPlayerCore.setRepeatMode(mode: RepeatMode) = withPlayerContext { setRepeatModeOnQueue(mode) }
 
 internal fun TrackPlayerCore.setRepeatModeOnQueue(mode: RepeatMode) {
+    val previousMode = currentRepeatMode
     currentRepeatMode = mode
     exo.setRepeatMode(
         when (mode) {
@@ -81,6 +82,11 @@ internal fun TrackPlayerCore.setRepeatModeOnQueue(mode: RepeatMode) {
             else -> Player.REPEAT_MODE_OFF
         },
     )
+    if (!isCastingField && previousMode != mode &&
+        (previousMode == RepeatMode.PLAYLIST || mode == RepeatMode.PLAYLIST)
+    ) {
+        rebuildQueueFromCurrentPosition()
+    }
 }
 
 fun TrackPlayerCore.getRepeatMode(): RepeatMode = currentRepeatMode

--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import com.margelo.nitro.nitroplayer.Reason
+import com.margelo.nitro.nitroplayer.RepeatMode
 import com.margelo.nitro.nitroplayer.TrackItem
 
 /**
@@ -120,6 +121,12 @@ internal fun TrackPlayerCore.rebuildQueueFromCurrentPosition() {
 
     val currentId = exo.currentMediaItem?.mediaId?.let { extractTrackId(it) }
     var newQueueTracks: List<TrackItem> = buildUpcomingQueueTracks(currentId)
+
+    if (!isCastingField && currentRepeatMode == RepeatMode.PLAYLIST &&
+        currentTrackIndex > 0 && currentTrackIndex <= currentTracks.size
+    ) {
+        newQueueTracks = newQueueTracks + currentTracks.subList(0, currentTrackIndex)
+    }
 
     if (isCastingField) {
         newQueueTracks = castableUpcoming(newQueueTracks)

--- a/react-native-nitro-player/ios/core/TrackPlayerCore.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerCore.swift
@@ -91,6 +91,7 @@ class TrackPlayerCore: NSObject {
   // track, not a real track change — so it must not emit onChangeTrack or reset
   // per-track state. Consumed (cleared) by the next `currentItemDidChange`.
   internal var suppressTrackChangeEmit = false
+  internal var lastCurrentItemTrackId: String?
   // Last observed playback position, used to resume after recreating a failed item.
   internal var lastKnownPosition: Double = 0
   // Per-track retry budget for recreating AVPlayerItems that hit status == .failed.

--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -387,7 +387,9 @@ extension TrackPlayerCore {
           NitroPlayerLogger.log("TrackPlayerCore", "   🎵 Track: \(track.title) - \(track.artist)")
           if oldIndex != index {
             NitroPlayerLogger.log("TrackPlayerCore", "   📢 Emitting onChangeTrack (index changed from \(oldIndex) to \(index))")
-            notifyTrackChange(track, .skip)
+            let wrappedToStart =
+              currentRepeatMode == .playlist && index == 0 && oldIndex == currentTracks.count - 1
+            notifyTrackChange(track, wrappedToStart ? .repeat : .skip)
           } else {
             NitroPlayerLogger.log("TrackPlayerCore", "   ⏭️ Skipping onChangeTrack emission (index unchanged)")
           }

--- a/react-native-nitro-player/ios/core/TrackPlayerListener.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerListener.swift
@@ -173,10 +173,12 @@ extension TrackPlayerCore {
     guard finishedItem.trackId != nil else { return }
 
     // 1. TRACK repeat — handle FIRST, before any temp-track removal
-    if currentRepeatMode == .track, finishedItem === player?.currentItem {
-      NitroPlayerLogger.log("TrackPlayerCore", "🔁 TRACK repeat — seeking to zero and replaying")
-      player?.seek(to: .zero)
-      player?.rate = Float(currentPlaybackSpeed)
+    if currentRepeatMode == .track {
+      if player?.currentItem == nil || player?.currentItem === finishedItem {
+        NitroPlayerLogger.log("TrackPlayerCore", "🔁 TRACK repeat — no queued copy, seeking to zero")
+        player?.seek(to: .zero)
+        player?.rate = Float(currentPlaybackSpeed)
+      }
       return  // do not remove temp tracks, do not notify track change (same track looping)
     }
 
@@ -293,6 +295,7 @@ extension TrackPlayerCore {
     guard let player, let currentItem = player.currentItem else {
       NitroPlayerLogger.log("TrackPlayerCore", "⚠️ Current item changed to nil")
       detachMetadataOutput()
+      lastCurrentItemTrackId = nil
       // Queue exhausted — handle PLAYLIST repeat
       if currentRepeatMode == .playlist && !currentTracks.isEmpty, let player = self.player {
         NitroPlayerLogger.log("TrackPlayerCore", "🔁 PLAYLIST repeat — rebuilding original queue and restarting")
@@ -317,6 +320,11 @@ extension TrackPlayerCore {
       }
       return
     }
+
+    let isRepeatLoop =
+      currentRepeatMode == .track && currentItem.trackId != nil
+      && currentItem.trackId == lastCurrentItemTrackId
+    lastCurrentItemTrackId = currentItem.trackId
 
     #if DEBUG
     NitroPlayerLogger.log("TrackPlayerCore", "\n" + String(repeating: "▶", count: Constants.separatorLineLength))
@@ -367,9 +375,9 @@ extension TrackPlayerCore {
         if currentTemporaryType == .playNext { tempTrack = playNextStack.first(where: { $0.id == trackId }) }
         else if currentTemporaryType == .upNext { tempTrack = upNextQueue.first(where: { $0.id == trackId }) }
         if let track = tempTrack {
-          if isRecoveryReplace {
+          if isRecoveryReplace || isRepeatLoop {
             NitroPlayerLogger.log("TrackPlayerCore",
-              "   ♻️ Recovery replace of temporary track '\(track.title)' — suppressing onChangeTrack")
+              "   ♻️ Same-track transition for '\(track.title)' — suppressing onChangeTrack")
           } else {
             NitroPlayerLogger.log("TrackPlayerCore", "   🎵 Temporary track: \(track.title) - \(track.artist)")
             NitroPlayerLogger.log("TrackPlayerCore", "   📢 Emitting onChangeTrack for temporary track")
@@ -415,7 +423,7 @@ extension TrackPlayerCore {
     // rebuildQueueFromPlaylistIndex (current track no longer in the playlist), which
     // replaces the current item and re-enters this callback. The length check makes any
     // such re-entry a no-op and terminate.
-    if player.items().count - 1 < Constants.queueWindowSize {
+    if currentRepeatMode == .track || player.items().count - 1 < Constants.queueWindowSize {
       rebuildAVQueueFromCurrentPosition()
     }
 

--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -74,11 +74,9 @@ extension TrackPlayerCore {
   func setRepeatModeOnQueue(mode: RepeatMode) {
     let previousMode = currentRepeatMode
     currentRepeatMode = mode
-    player?.actionAtItemEnd = (mode == .track) ? .none : .advance
+    player?.actionAtItemEnd = .advance
     if isCasting { castManager?.setQueueRepeatMode(mode) }
-    if !isCasting, previousMode != mode, previousMode == .playlist || mode == .playlist,
-      player?.currentItem != nil
-    {
+    if !isCasting, previousMode != mode, player?.currentItem != nil {
       rebuildAVQueueFromCurrentPosition()
     }
     NitroPlayerLogger.log("TrackPlayerCore", "🔁 setRepeatMode: \(mode)")
@@ -258,6 +256,14 @@ extension TrackPlayerCore {
       }
       checkUpcomingTracksForUrls(lookahead: lookaheadCount)
       return
+    }
+
+    if currentRepeatMode == .track {
+      let items = queuePlayer.items()
+      if items.count > 1, let copyId = items[1].trackId, copyId == items[0].trackId {
+        queuePlayer.remove(items[1])
+      }
+      rebuildAVQueueFromCurrentPosition(skipRepeatCopy: true)
     }
 
     // Remove current temp track from its list before advancing

--- a/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerPlayback.swift
@@ -72,9 +72,15 @@ extension TrackPlayerCore {
   func skipToPrevious() async { await withPlayerQueueNoThrow { self.skipToPreviousOnQueue() } }
 
   func setRepeatModeOnQueue(mode: RepeatMode) {
+    let previousMode = currentRepeatMode
     currentRepeatMode = mode
     player?.actionAtItemEnd = (mode == .track) ? .none : .advance
     if isCasting { castManager?.setQueueRepeatMode(mode) }
+    if !isCasting, previousMode != mode, previousMode == .playlist || mode == .playlist,
+      player?.currentItem != nil
+    {
+      rebuildAVQueueFromCurrentPosition()
+    }
     NitroPlayerLogger.log("TrackPlayerCore", "🔁 setRepeatMode: \(mode)")
   }
   func setRepeatMode(mode: RepeatMode) async {

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -272,7 +272,9 @@ extension TrackPlayerCore {
   ///
   /// - Parameter changedTrackIds: When non-nil, performs a surgical update:
   ///   only AVPlayerItems whose track ID is in this set are removed and re-created.
-  func rebuildAVQueueFromCurrentPosition(changedTrackIds: Set<String>? = nil) {
+  func rebuildAVQueueFromCurrentPosition(
+    changedTrackIds: Set<String>? = nil, skipRepeatCopy: Bool = false
+  ) {
     // While casting, queue changes are applied to the receiver — the local AVQueuePlayer is dormant.
     if isCasting {
       syncCastQueueAfterCurrent()
@@ -343,6 +345,14 @@ extension TrackPlayerCore {
 
     if currentRepeatMode == .playlist, currentTrackIndex > 0, currentTrackIndex <= currentTracks.count {
       newQueueTracks.append(contentsOf: currentTracks[0..<currentTrackIndex])
+    }
+
+    if currentRepeatMode == .track, !skipRepeatCopy {
+      let repeated =
+        playNextStack.first(where: { $0.id == playingTrackId })
+        ?? upNextQueue.first(where: { $0.id == playingTrackId })
+        ?? currentTracks.first(where: { $0.id == playingTrackId })
+      if let repeated = repeated { newQueueTracks = [repeated] }
     }
 
     // Window the materialized queue — currentItemDidChange tops it up on every transition.
@@ -534,7 +544,10 @@ extension TrackPlayerCore {
     }
 
     let asset: AVURLAsset
-    if let preloadedAsset = preloadedAssets[track.id] {
+    let preloaded = preloadedAssets[track.id]
+    let preloadedInUse =
+      preloaded != nil && (player?.items().contains { ($0.asset as? AVURLAsset) === preloaded } ?? false)
+    if let preloadedAsset = preloaded, !preloadedInUse {
       asset = preloadedAsset
       NitroPlayerLogger.log("TrackPlayerCore", "🚀 Using preloaded asset for \(track.title)")
     } else {

--- a/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
+++ b/react-native-nitro-player/ios/core/TrackPlayerQueueBuild.swift
@@ -341,6 +341,10 @@ extension TrackPlayerCore {
       newQueueTracks.append(contentsOf: currentTracks[(currentTrackIndex + 1)...])
     }
 
+    if currentRepeatMode == .playlist, currentTrackIndex > 0, currentTrackIndex <= currentTracks.count {
+      newQueueTracks.append(contentsOf: currentTracks[0..<currentTrackIndex])
+    }
+
     // Window the materialized queue — currentItemDidChange tops it up on every transition.
     if newQueueTracks.count > Constants.queueWindowSize {
       newQueueTracks.removeSubrange(Constants.queueWindowSize...)
@@ -571,9 +575,13 @@ extension TrackPlayerCore {
     let queuedTrackIds = Set(player?.items().compactMap { $0.trackId } ?? [])
     let alreadyPreloaded = Set(preloadedAssets.keys)
     let generation = preloadGeneration
-    let endIndex = min(startIndex + Constants.gaplessPreloadCount, currentTracks.count)
-    guard startIndex >= 0, startIndex < endIndex else { return }
-    let candidates = Array(currentTracks[startIndex..<endIndex])
+    let wraps = currentRepeatMode == .playlist && !currentTracks.isEmpty
+    let available =
+      wraps
+      ? min(Constants.gaplessPreloadCount, currentTracks.count)
+      : max(0, min(startIndex + Constants.gaplessPreloadCount, currentTracks.count) - startIndex)
+    guard startIndex >= 0, available > 0 else { return }
+    let candidates = (0..<available).map { currentTracks[(startIndex + $0) % currentTracks.count] }
 
     preloadQueue.async { [weak self] in
       guard let self else { return }
@@ -631,10 +639,20 @@ extension TrackPlayerCore {
   /// Clears preloaded assets that are no longer needed
   func cleanupPreloadedAssets(keepingFrom currentIndex: Int) {
     // Already on playerQueue — access preloadedAssets directly
-    let keepRange =
-      currentIndex..<min(
-        currentIndex + Constants.gaplessPreloadCount + 1, self.currentTracks.count)
-    let keepIds = Set(keepRange.compactMap { self.currentTracks[safe: $0]?.id })
+    let keepIds: Set<String>
+    if currentRepeatMode == .playlist, !self.currentTracks.isEmpty {
+      let start = max(0, currentIndex)
+      let keepCount = min(Constants.gaplessPreloadCount + 1, self.currentTracks.count)
+      keepIds = Set(
+        (0..<keepCount).compactMap {
+          self.currentTracks[safe: (start + $0) % self.currentTracks.count]?.id
+        })
+    } else {
+      let keepRange =
+        currentIndex..<min(
+          currentIndex + Constants.gaplessPreloadCount + 1, self.currentTracks.count)
+      keepIds = Set(keepRange.compactMap { self.currentTracks[safe: $0]?.id })
+    }
 
     let assetsToRemove = self.preloadedAssets.keys.filter { !keepIds.contains($0) }
     for id in assetsToRemove {


### PR DESCRIPTION
## Problem

With `repeatMode = 'Playlist'`, looping back to the start of the queue was a stop-and-restart, not a wrap — audible gap between the last track and track 0.

The materialized player window stops at the end of the playlist on both platforms:

- iOS `rebuildAVQueueFromCurrentPosition` only appended `currentTracks[(currentTrackIndex + 1)...]`, so on the last track nothing upcoming was queued. `AVQueuePlayer` drained, `currentItem` went nil, and only then did the listener rebuild items from index 0 — a fresh `AVPlayerItem` with a cold asset load.
- Android `buildUpcomingQueueTracks` did the same, so ExoPlayer hit `STATE_ENDED` and `rebuildQueueAndPlayFromIndex(0)` ran `setMediaItems` + `prepare()` from scratch.

iOS also never preloaded track 0: `preloadUpcomingTracks(from:)` and `cleanupPreloadedAssets(keepingFrom:)` both clamp to `currentTracks.count`.

## Fix

Wrap the window when repeat mode is `Playlist`: after the tail slice, append `currentTracks[0..<currentTrackIndex]`. That's exactly one rotation minus the current track, so no track is ever duplicated in the timeline, and the existing window truncation still caps it at `QUEUE_WINDOW_SIZE`. The loop transition then becomes an ordinary gapless item transition.

- iOS: wrap in `rebuildAVQueueFromCurrentPosition`, plus matching wrap in `preloadUpcomingTracks` and `cleanupPreloadedAssets` so track 0's asset is preloaded and not immediately purged.
- Android: wrap in `rebuildQueueFromCurrentPosition`, skipped while casting (the receiver holds the whole queue unwindowed).

`onChangeTrack` still reports `reason: 'repeat'` on the wrap — previously that came from the drain handlers, now it's detected on the transition (last index → 0).

The `STATE_ENDED` / `currentItem == nil` repeat handlers are left in place as a fallback for edge cases (empty window, casting).

## Verification

- `./gradlew :react-native-nitro-player:compileDebugKotlin` — green
- `xcodebuild -project Pods/Pods.xcodeproj -target NitroPlayer -sdk iphonesimulator -arch arm64` — **BUILD SUCCEEDED**

Runtime check still worth doing: play to the end of a queue with `repeatMode = 'Playlist'` on both platforms and confirm the wrap into track 0 is gapless.

## Repeat-mode toggling

The window is materialized ahead of playback, so a repeat-mode change has to re-window it:

- Turning repeat **off** while wrapped items were already queued would otherwise still play track 0 after the last track.
- Turning repeat **on** during the last track would otherwise never wrap, because no further transition tops the window up.

`setRepeatModeOnQueue` now calls the rebuild on both platforms when the mode changes into or out of `Playlist`. No-op while casting, and no-op when nothing is playing.

## Track repeat (same song)

Android was already fine — `RepeatMode.TRACK` maps to ExoPlayer `REPEAT_MODE_ONE`, which re-prepares the repeated period before the current one ends.

iOS had the same class of bug, with a bigger gap. `actionAtItemEnd` was `.none`, so the player stopped at the end of the item and the end notification seeked back to zero. That seek lands on a position whose buffer was evicted a whole song ago — on a remote stream it's a fresh range request on every loop.

Now the window builder materializes a copy of the current track as the sole upcoming item when repeat is `track`, and `.advance` walks into it, preloaded. The end handler keeps its early return (no temp-list removal, no track-change emit) and only seeks as a fallback when no copy was queued. `currentItemDidChange` re-arms the copy on every transition, so the loop is self-sustaining and survives skips and `playFromIndex`.

Supporting changes:

- `skipToNextInternal` drops the queued copy and re-materializes the real upcoming tracks first, so a manual skip moves on instead of replaying the song.
- `onChangeTrack` is suppressed on the loop. The original-track path already did this via the unchanged index; temp tracks (playNext / upNext) needed `lastCurrentItemTrackId` to tell a loop from a genuine change. Matches Android, which skips the callback on `MEDIA_ITEM_TRANSITION_REASON_REPEAT`.
- `createGaplessPlayerItem` no longer hands a preloaded `AVURLAsset` to a second item while another live item is still backed by it. The resource-loader delegate (the http→https redirect resolver) is per-asset, so two concurrent items would race it.

Note that `actionAtItemEnd` is now unconditionally `.advance`, reverting the earlier `.none` fix. That fix existed because `.advance` moved to the *next* track before the async seek could run. Here the next item is the same track by construction, and the fallback seek covers the case where no copy was materialized.
