### PR TITLE
fix: next track never plays on Android with lazy URLs

### DIFF
--- a/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
+++ b/react-native-nitro-player/android/src/main/java/com/margelo/nitro/nitroplayer/core/TrackPlayerQueueBuild.kt
@@ -158,9 +158,13 @@ internal fun TrackPlayerCore.rebuildQueueFromCurrentPosition() {
     // ExoPlayer has already prepared, so gapless transitions survive.
     val existingCount = exo.mediaItemCount - currentIndex - 1
     var commonPrefix = 0
-    while (commonPrefix < existingCount && commonPrefix < newQueueTracks.size &&
-        extractTrackId(exo.getMediaItemAt(currentIndex + 1 + commonPrefix).mediaId) == newQueueTracks[commonPrefix].id
-    ) {
+    while (commonPrefix < existingCount && commonPrefix < newQueueTracks.size) {
+        val existing = exo.getMediaItemAt(currentIndex + 1 + commonPrefix)
+        val track = newQueueTracks[commonPrefix]
+        if (extractTrackId(existing.mediaId) != track.id) break
+        // URI must match too — items materialized before lazy URL resolution are unplayable
+        val desiredUrl = if (isCastingField) track.url else downloadManager.getEffectiveUrl(track)
+        if (existing.localConfiguration?.uri?.toString().orEmpty() != desiredUrl) break
         commonPrefix++
     }
 


### PR DESCRIPTION
Fixes #168

## Root cause
Regression from #117 (`2701bfd`, shipped in 1.6.0). Lazy tracks (empty URL) are materialized into ExoPlayer's windowed timeline as MediaItems with an empty URI. When JS resolves URLs via `updateTracks`, `rebuildQueueFromCurrentPosition` keeps already-queued items via a common-prefix check that compared **mediaId only** — so the stale empty-URI items stayed in the timeline. Track end or `skipToNext` then hit one:

```
ExoPlaybackException: Source error
Caused by: FileDataSource$FileDataSourceException: FileNotFoundException: : open failed: ENOENT
```

`skipToPrevious` worked because it goes through a full `setMediaItems` rebuild with fresh URLs. iOS unaffected.

## Fix
Prefix match now also requires the existing item's URI to equal the currently desired URL (`track.url` while casting, `downloadManager.getEffectiveUrl(track)` otherwise). One choke point covers auto-advance top-up, `skipToNext`, and every other rebuild caller. Unresolved tracks still match (empty == empty), so there is no rebuild churn.

## Verification
Reproduced on emulator with the example app's "Lazy Loaded Tracks" playlist: before the fix, `skipToNext` → buffering → `stopped` with the ENOENT source error; after the fix, lazy-2 and lazy-3 both play with advancing position and zero playback errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)